### PR TITLE
add ch_fasta to FUNCTIONAL_ANNOTATION subworkflow as input to annotators

### DIFF
--- a/subworkflows/local/functional_annotation/main.nf
+++ b/subworkflows/local/functional_annotation/main.nf
@@ -1,4 +1,4 @@
-// Import Annotator Subworfklows 
+// Import Annotator Subworfklows
 
 workflow FUNCTIONAL_ANNOTATION {
 

--- a/subworkflows/local/functional_annotation/main.nf
+++ b/subworkflows/local/functional_annotation/main.nf
@@ -1,3 +1,5 @@
+// Import Annotator Subworfklows 
+
 workflow FUNCTIONAL_ANNOTATION {
 
     take:
@@ -9,9 +11,25 @@ workflow FUNCTIONAL_ANNOTATION {
 
     // TODO nf-core: substitute modules here for the modules of your subworkflow
 
+    // Create a multifasta, with one fasta per entry, add the sequence ID to the meta id
+    ch_fasta
+        .map {
+            meta, fasta ->
+            [
+                [id:"${meta.id}_${fasta[0].splitFasta(record: [id: true]).id[0].replaceAll(/\|/, '-')}"] ,
+                fasta[0].splitFasta(file:true)
+            ]
+        }
+        .transpose()
+        .view()
+        .set { ch_multifasta }
+
+    //
+    // SUBWORKFLOW: Annotator Name
+    //
+
     emit:
     // TODO nf-core: edit emitted channels
 
     versions = ch_versions                     // channel: [ versions.yml ]
 }
-


### PR DESCRIPTION
<!--
# nf-core/proteinannotator pull request
This branch just adds `ch_multifasta` into the FUNCTIONAL_ANNOTATION workflow so that it is available as input for the various annotator tools that will be added to the FUNCTIONAL_ANNOTATION subworkflow.


Many thanks for contributing to nf-core/proteinannotator!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinannotator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
