### PR TITLE
qc and preprocessing nf-core subworkflow added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ Initial release of nf-core/proteinannotator, created with the [nf-core](https://
 
 ### `Added`
 
-- [[PR #52](https://github.com/nf-core/proteinannotator/pull/52)] Add option to turn off InterProScan for testing
-- [[PR #51](https://github.com/nf-core/proteinannotator/pull/51)] Update to nf-core/tools v3.3.1
-- [[PR #47](https://github.com/nf-core/proteinannotator/pull/47)] Update metromap with more tools added from [May 2025 Hackathon](https://nf-co.re/events/2025/hackathon-boston)
-- [[PR #43](https://github.com/nf-core/proteinannotator/pull/44)] Add [mTM-Align](https://nf-co.re/modules/mtmalign_align/) and [MMseqs2 Search](https://nf-co.re/modules/mmseqs_search/) modules
-- [[PR #42](https://github.com/nf-core/proteinannotator/pull/42)] Updated to `nf-test` on GitHub Actions and in the `PULL_REQUEST_TEMPLATE.md`
-- [[PR #13](https://github.com/nf-core/proteinannotator/pull/13)] Add nf-core seqkit/stats module
-- [[PR #9](https://github.com/nf-core/proteinannotator/pull/9)] Add [InterProScan](https://interproscan-docs.readthedocs.io/) module
+- [#59](https://github.com/nf-core/proteinannotator/pull/59) - Added nf-core qc and pre-processing subworkflow for amino acid sequences `FAA_SEQFU_SEQKIT`. (by @vagkaratzas). (by @vagkaratzas)
+- [#57](https://github.com/nf-core/proteinannotator/pull/57) - nf-core tools template update to 3.5.1. (by @vagkaratzas)
+- [#52](https://github.com/nf-core/proteinannotator/pull/52) - Add option to turn off InterProScan for testing
+- [#51](https://github.com/nf-core/proteinannotator/pull/51) - Update to nf-core/tools v3.3.1
+- [#47](https://github.com/nf-core/proteinannotator/pull/47) - Update metromap with more tools added from [May 2025 Hackathon](https://nf-co.re/events/2025/hackathon-boston)
+- [#43](https://github.com/nf-core/proteinannotator/pull/44) - Add [mTM-Align](https://nf-co.re/modules/mtmalign_align/) and [MMseqs2 Search](https://nf-co.re/modules/mmseqs_search/) modules
+- [#42](https://github.com/nf-core/proteinannotator/pull/42) - Updated to `nf-test` on GitHub Actions and in the `PULL_REQUEST_TEMPLATE.md`
+- [#13](https://github.com/nf-core/proteinannotator/pull/13) - Add nf-core seqkit/stats module
+- [#9](https://github.com/nf-core/proteinannotator/pull/9) - Add [InterProScan](https://interproscan-docs.readthedocs.io/) module
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Initial release of nf-core/proteinannotator, created with the [nf-core](https://
 - [#52](https://github.com/nf-core/proteinannotator/pull/52) - Add option to turn off InterProScan for testing
 - [#51](https://github.com/nf-core/proteinannotator/pull/51) - Update to nf-core/tools v3.3.1
 - [#47](https://github.com/nf-core/proteinannotator/pull/47) - Update metromap with more tools added from [May 2025 Hackathon](https://nf-co.re/events/2025/hackathon-boston)
-- [#43](https://github.com/nf-core/proteinannotator/pull/44) - Add [mTM-Align](https://nf-co.re/modules/mtmalign_align/) and [MMseqs2 Search](https://nf-co.re/modules/mmseqs_search/) modules
+<!-- - [#43](https://github.com/nf-core/proteinannotator/pull/44) - Add [mTM-Align](https://nf-co.re/modules/mtmalign_align/) and [MMseqs2 Search](https://nf-co.re/modules/mmseqs_search/) modules -->
 - [#42](https://github.com/nf-core/proteinannotator/pull/42) - Updated to `nf-test` on GitHub Actions and in the `PULL_REQUEST_TEMPLATE.md`
 - [#13](https://github.com/nf-core/proteinannotator/pull/13) - Add nf-core seqkit/stats module
 - [#9](https://github.com/nf-core/proteinannotator/pull/9) - Add [InterProScan](https://interproscan-docs.readthedocs.io/) module

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -10,21 +10,29 @@
 
 ## Pipeline tools
 
-- [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
+- [SeqFu](https://pubmed.ncbi.nlm.nih.gov/34066939/)
 
-> Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
+> Telatin A, Fariselli P, Birolo G. SeqFu: a suite of utilities for the robust and reproducible manipulation of sequence files. Bioengineering. 2021 May 7;8(5):59. doi: 10.3390/bioengineering8050059. PubMed PMID: 34066939; PubMed Central PMCID: PMC8148589.
+
+- [SeqKit](https://pubmed.ncbi.nlm.nih.gov/38898985/)
+
+> Shen W, Sipos B, Zhao L. SeqKit2: A Swiss army knife for sequence and alignment processing. iMeta. 2024 Apr 5:e191. doi: 10.1002/imt2.191. PubMed PMID: 38898985; PubMed Central PMCID: PMC11183193.
 
 - [InterProScan](https://academic.oup.com/bioinformatics/article/17/9/847/206564)
 
 > Zdobnov, Evgeni M., and Rolf Apweiler. “InterProScan – an Integration Platform for the Signature-Recognition Methods in InterPro.” Bioinformatics 17, no. 9 (September 1, 2001): 847–48. https://doi.org/10.1093/bioinformatics/17.9.847.
 
-- [MMseqs2](https://www.nature.com/articles/nbt.3988)
+<!-- - [MMseqs2](https://www.nature.com/articles/nbt.3988)
 
 > Zdobnov, Evgeni M., and Rolf Apweiler. “InterProScan – an Integration Platform for the Signature-Recognition Methods in InterPro.” Bioinformatics 17, no. 9 (September 1, 2001): 847–48. https://doi.org/10.1093/bioinformatics/17.9.847.
 
 - [mTM-align](https://academic.oup.com/bioinformatics/article/34/10/1719/4769500)
 
-> Dong, Runze, Zhenling Peng, Yang Zhang, and Jianyi Yang. “mTM-Align: An Algorithm for Fast and Accurate Multiple Protein Structure Alignment.” Bioinformatics 34, no. 10 (May 15, 2018): 1719–25. https://doi.org/10.1093/bioinformatics/btx828.
+> Dong, Runze, Zhenling Peng, Yang Zhang, and Jianyi Yang. “mTM-Align: An Algorithm for Fast and Accurate Multiple Protein Structure Alignment.” Bioinformatics 34, no. 10 (May 15, 2018): 1719–25. https://doi.org/10.1093/bioinformatics/btx828. -->
+
+- [MultiQC](https://pubmed.ncbi.nlm.nih.gov/27312411/)
+
+> Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics. 2016 Oct 1;32(19):3047-8. doi: 10.1093/bioinformatics/btw354. Epub 2016 Jun 16. PubMed PMID: 27312411; PubMed Central PMCID: PMC5039924.
 
 ## Software packaging/containerisation tools
 

--- a/assets/methods_description_template.yml
+++ b/assets/methods_description_template.yml
@@ -3,7 +3,6 @@ description: "Suggested text and references to use when describing pipeline usag
 section_name: "nf-core/proteinannotator Methods Description"
 section_href: "https://github.com/nf-core/proteinannotator"
 plot_type: "html"
-## TODO nf-core: Update the HTML below to your preferred methods description, e.g. add publication citation for this pipeline
 ## You inject any metadata in the Nextflow '${workflow}' object
 data: |
   <h4>Methods</h4>

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,6 +18,62 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:FAA_SEQFU_SEQKIT:SEQFU_STATS_BEFORE' {
+        ext.prefix = { "${meta.id}_before" }
+        publishDir = [
+            path: { "${params.outdir}/qc/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:FAA_SEQFU_SEQKIT:SEQFU_STATS_AFTER' {
+        ext.prefix = { "${meta.id}_after" }
+        publishDir = [
+            path: { "${params.outdir}/qc/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:FAA_SEQFU_SEQKIT:SEQKIT_SEQ' {
+        ext.args = [
+            "--remove-gaps",
+            "--upper-case",
+            "--validate-seq",
+            "--min-len ${params.min_seq_length}",
+            "--max-len ${params.max_seq_length}"
+        ].join(' ').trim()
+        ext.prefix = "intermediate_seqkit_seq"
+        publishDir = [
+            path: { "${params.outdir}/qc/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            enabled: false,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:FAA_SEQFU_SEQKIT:SEQKIT_REPLACE' {
+        ext.args   = '-p "/" -r "_"'
+        ext.suffix = "fasta"
+        ext.prefix = "intermediate_seqkit_replace"
+        publishDir = [
+            path: { "${params.outdir}/qc/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            enabled: false,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:FAA_SEQFU_SEQKIT:SEQKIT_RMDUP' {
+        ext.args   = { params.remove_duplicates_on_sequence ? "--by-seq" : '' }
+        publishDir = [
+            path: { "${params.outdir}/qc/${meta.id}/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: 'MULTIQC' {
         ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
         publishDir = [
@@ -27,7 +83,4 @@ process {
         ]
     }
 
-    withName: SEQKIT_STATS {
-        ext.args = ' ' // turn off --all default argument
-    }
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -12,11 +12,50 @@ The directories listed below will be created in the results directory after the 
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
 
+- [Quality check and preprocessing](#quality-check-and-preprocessing)
+  - [SeqFu](#seqfu) for input amino acid sequences quality check (QC)
+  - [SeqKit](#seqkit) for preprocessing input amino acid sequences (i.e., gap removal, convert to upper case, validate, filter by length, replace special characters such as `/`, and remove duplicate sequences)
+
 - [Functional Annotation](#functional-annotation) Annotate proteins with functional domains
   - [InterProScan](#Interproscan) - Search the InterPro database for functional domains
 - [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
-- [SeqKit stats](#seqkit_stats) - Simple statistics for protein FASTA files
 - [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+
+### Quality check and preprocessing
+
+#### SeqFu
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `qc/`
+  - `<samplename>/`
+    - `<samplename>_before.tsv`: Statistics for the input amino acid sequences before preprocessing
+    - `<samplename>_before_mqc.txt`: Statistics for the input amino acid sequences in MultiQC-ready format before preprocessing
+    - `<samplename>_after.tsv`: (optional) Statistics for the input amino acid sequences after preprocessing
+    - `<samplename>_after_mqc.txt`: (optional) Statistics for the input amino acid sequences in MultiQC-ready format after preprocessing
+    - `<samplename>.log`: (optional) Output file with count of duplicate sequences that were found and removed
+
+</details>
+
+The `seqfu` module is used for statistics generation of input amino acid sequences, both before and after preprocessing.
+
+[SeqFu](https://github.com/telatin/seqfu2) is a cross-platform compiled suite of tools to manipulate and inspect `FASTA` and `FASTQ` files.
+
+#### SeqKit
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `qc/`
+  - `<samplename>/`
+    - `<samplename>.<suffix>`: Updated preprocessed input fasta file
+
+</details>
+
+The `seqkit` module is used for initial preprocessing (i.e., gap removal, convert to upper case, validate, filter by length, replace special characters such as `/`, and remove duplicate sequences) of the input amino acid sequences.
+
+[SeqKit](https://github.com/shenwei356/seqkit) is a cross-platform and ultrafast toolkit for FASTA/Q file manipulation.
 
 ### Functional Annotation
 

--- a/main.nf
+++ b/main.nf
@@ -38,7 +38,8 @@ workflow NFCORE_PROTEINANNOTATOR {
     // WORKFLOW: Run pipeline
     //
     PROTEINANNOTATOR (
-        samplesheet
+        samplesheet,
+        params.skip_preprocessing
     )
     emit:
     multiqc_report = PROTEINANNOTATOR.out.multiqc_report // channel: /path/to/multiqc_report.html

--- a/modules.json
+++ b/modules.json
@@ -20,6 +20,26 @@
                         "git_sha": "af27af1be706e6a2bb8fe454175b0cdf77f47b49",
                         "installed_by": ["modules"]
                     },
+                    "seqfu/stats": {
+                        "branch": "master",
+                        "git_sha": "e753770db613ce014b3c4bc94f6cba443427b726",
+                        "installed_by": ["faa_seqfu_seqkit"]
+                    },
+                    "seqkit/replace": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["faa_seqfu_seqkit"]
+                    },
+                    "seqkit/rmdup": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["faa_seqfu_seqkit"]
+                    },
+                    "seqkit/seq": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["faa_seqfu_seqkit"]
+                    },
                     "seqkit/stats": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
@@ -34,6 +54,11 @@
             },
             "subworkflows": {
                 "nf-core": {
+                    "faa_seqfu_seqkit": {
+                        "branch": "master",
+                        "git_sha": "15c0a7968179d3b717a9973a1c4f25beb8a9aa2b",
+                        "installed_by": ["subworkflows"]
+                    },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",

--- a/modules/nf-core/seqfu/stats/environment.yml
+++ b/modules/nf-core/seqfu/stats/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqfu=1.22.3

--- a/modules/nf-core/seqfu/stats/main.nf
+++ b/modules/nf-core/seqfu/stats/main.nf
@@ -1,0 +1,52 @@
+process SEQFU_STATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqfu:1.22.3--hfd12232_2':
+        'biocontainers/seqfu:1.22.3--hfd12232_2' }"
+
+    input:
+    // stats can get one or more fasta or fastq files
+    tuple val(meta), path(files)
+
+    output:
+    tuple val(meta), path("*.tsv")    , emit: stats
+    tuple val(meta), path("*_mqc.txt"), emit: multiqc
+    path "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    seqfu \\
+        stats \\
+        $args \\
+        --multiqc ${prefix}_mqc.txt \\
+        $files > ${prefix}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqfu: \$(seqfu version)
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    echo $args
+
+    touch ${prefix}.tsv
+    touch ${prefix}_mqc.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqfu: \$(seqfu version)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqfu/stats/meta.yml
+++ b/modules/nf-core/seqfu/stats/meta.yml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "seqfu_stats"
+description: Statistics for FASTA or FASTQ files
+keywords:
+  - seqfu
+  - stats
+  - n50
+tools:
+  - "seqfu":
+      description: "Cross-platform compiled suite of tools to manipulate and inspect
+        FASTA and FASTQ files"
+      homepage: "https://telatin.github.io/seqfu2/"
+      documentation: "https://telatin.github.io/seqfu2/"
+      tool_dev_url: "https://github.com/telatin/seqfu2"
+      doi: "10.3390/bioengineering8050059"
+      licence: ["GPL v3"]
+      identifier: biotools:seqfu
+
+input:
+  # Only when we have meta
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - files:
+        type: file
+        description: One or more FASTA or FASTQ files
+        pattern: "*.{fasta,fastq,fasta.gz,fastq.gz,fq,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  #Only when we have meta
+  stats:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*.tsv":
+          type: file
+          description: Tab-separated output file with basic sequence statistics.
+          pattern: "*.{tsv}"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  multiqc:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - "*_mqc.txt":
+          type: file
+          description: MultiQC ready table
+          pattern: "*.{_mqc.txt}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@telatin"
+maintainers:
+  - "@telatin"

--- a/modules/nf-core/seqfu/stats/tests/main.nf.test
+++ b/modules/nf-core/seqfu/stats/tests/main.nf.test
@@ -1,0 +1,88 @@
+nextflow_process {
+
+    name "Test Process SEQFU_STATS"
+    script "../main.nf"
+    process "SEQFU_STATS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqfu"
+    tag "seqfu/stats"
+
+    test("seqfu stats - faa") {
+        // test with 1 FAA file (with  multiple sequences of different length)
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_faa' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("seqfu stats - multiple files") {
+        // test feeding a mix of files including compressed
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test_multiple' ],
+                            [
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true),
+                                file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                        ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("seqfu stats - faa - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success},
+                { assert snapshot(
+                    process.out,
+                    process.out.versions.collect{ path(it).yaml }
+                ).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/seqfu/stats/tests/main.nf.test.snap
+++ b/modules/nf-core/seqfu/stats/tests/main.nf.test.snap
@@ -1,0 +1,156 @@
+{
+    "seqfu stats - faa - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ]
+            },
+            [
+                {
+                    "SEQFU_STATS": {
+                        "seqfu": "1.22.3"
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-24T12:51:50.35812127"
+    },
+    "seqfu stats - faa": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa.tsv:md5,0d6bf2cc788f7828761440a1689cac04"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_mqc.txt:md5,8f3c2edaf1ea5be912c9f99b21b2856c"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_mqc.txt:md5,8f3c2edaf1ea5be912c9f99b21b2856c"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa.tsv:md5,0d6bf2cc788f7828761440a1689cac04"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-24T12:52:03.19664223"
+    },
+    "seqfu stats - multiple files": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_multiple"
+                        },
+                        "test_multiple.tsv:md5,d016de3d84187a06c8e19b8dabccb3ae"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_multiple"
+                        },
+                        "test_multiple_mqc.txt:md5,dbc6e762eebbf756cd0687807de60445"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ],
+                "multiqc": [
+                    [
+                        {
+                            "id": "test_multiple"
+                        },
+                        "test_multiple_mqc.txt:md5,dbc6e762eebbf756cd0687807de60445"
+                    ]
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test_multiple"
+                        },
+                        "test_multiple.tsv:md5,d016de3d84187a06c8e19b8dabccb3ae"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,7e7581ee4a87fd1f9969628ae050e689"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.6"
+        },
+        "timestamp": "2025-09-24T12:52:11.315174611"
+    }
+}

--- a/modules/nf-core/seqkit/replace/environment.yml
+++ b/modules/nf-core/seqkit/replace/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqkit=2.9.0

--- a/modules/nf-core/seqkit/replace/main.nf
+++ b/modules/nf-core/seqkit/replace/main.nf
@@ -1,0 +1,62 @@
+process SEQKIT_REPLACE {
+    tag "${meta.id}"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0'
+        : 'biocontainers/seqkit:2.9.0--h9ee0642_0'}"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("*.fast*"), emit: fastx
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.faa|.+\.faa.gz/) {
+        extension = "fasta"
+    }
+    def isgz = ""
+    if ("${fastx}" ==~ /.+\.gz/) {
+        isgz = ".gz"
+    }
+    def endswith = task.ext.suffix ?: "${extension}${isgz}"
+    """
+    seqkit \\
+        replace \\
+        ${args} \\
+        --threads ${task.cpus} \\
+        -i ${fastx} \\
+        -o ${prefix}.${endswith}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$( seqkit version | sed 's/seqkit v//' )
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz/) {
+        extension = "fasta"
+    }
+    def endswith = task.ext.suffix ?: "${extension}.gz"
+
+    """
+    echo "" | gzip > ${prefix}.${endswith}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$( seqkit version | sed 's/seqkit v//' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqkit/replace/meta.yml
+++ b/modules/nf-core/seqkit/replace/meta.yml
@@ -1,0 +1,53 @@
+name: seqkit_replace
+description: Use seqkit to find/replace strings within sequences and sequence headers
+keywords:
+  - seqkit
+  - replace
+  - sequence
+  - sequence headers
+  - fasta
+tools:
+  - seqkit:
+      description: Cross-platform and ultrafast toolkit for FASTA/Q file manipulation,
+        written by Wei Shen.
+      homepage: https://bioinf.shenwei.me/seqkit/usage/
+      documentation: https://bioinf.shenwei.me/seqkit/usage/
+      tool_dev_url: https://github.com/shenwei356/seqkit/
+      doi: "10.1371/journal.pone.016396"
+      identifier: biotools:seqkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fastx:
+        type: file
+        description: fasta/q file
+        pattern: "*.{fasta,fastq,fa,fq,fas,fna,faa}*"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  fastx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fast*":
+          type: file
+          description: fasta/q file with replaced values
+          pattern: "*.{fasta,fastq,fa,fq,fas,fna,faa}*"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@mjcipriano"
+maintainers:
+  - "@mjcipriano"

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test
@@ -1,0 +1,105 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_REPLACE"
+    script "../main.nf"
+    process "SEQKIT_REPLACE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/replace"
+
+    test("sarscov2 - fasta - replace") {
+
+        config "./replace.config"
+
+        when {
+            process {
+                """
+                    input[0] = [ [ id:'test' ],   // meta map
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta.gz', checkIfExists: true) ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+
+    test("sarscov2 - fasta - replace - uncompressed") {
+
+        config "./replace.config"
+
+        when {
+            process {
+                """
+                    input[0] = [ [ id:'test' ],   // meta map
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - uncomp - custom") {
+
+        config "./uncomp.config"
+
+        when {
+            process {
+                """
+                    input[0] = [ [ id:'test' ],   // meta map
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                    input[0] = [ [ id:'test' ],   // meta map
+                                 [ file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true) ]
+                    ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
@@ -1,0 +1,134 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:10:45.336609"
+    },
+    "sarscov2 - fasta - replace - uncompressed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,b1518908253a4997fcad98270751112e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,b1518908253a4997fcad98270751112e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-23T11:36:29.526831467"
+    },
+    "sarscov2 - fasta - uncomp - custom": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test..fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-23T11:36:34.791793064"
+    },
+    "sarscov2 - fasta - replace": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,c40eaff961f6f2a48bb7e8fd156ed5d7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,c40eaff961f6f2a48bb7e8fd156ed5d7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,edcad74f001a6cf3a54d2a99bd532b50"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-23T11:36:24.47433864"
+    }
+}

--- a/modules/nf-core/seqkit/replace/tests/replace.config
+++ b/modules/nf-core/seqkit/replace/tests/replace.config
@@ -1,0 +1,5 @@
+ process {
+    withName: 'SEQKIT_REPLACE' {
+        ext.args   = "-s -p 'A' -r 'N'"
+    }
+ }

--- a/modules/nf-core/seqkit/replace/tests/uncomp.config
+++ b/modules/nf-core/seqkit/replace/tests/uncomp.config
@@ -1,0 +1,6 @@
+ process {
+    withName: 'SEQKIT_REPLACE' {
+        ext.args          = "-s -p 'T' -r 'N'"
+        ext.suffix        = ".fasta"
+    }
+ }

--- a/modules/nf-core/seqkit/rmdup/environment.yml
+++ b/modules/nf-core/seqkit/rmdup/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqkit=2.9.0

--- a/modules/nf-core/seqkit/rmdup/main.nf
+++ b/modules/nf-core/seqkit/rmdup/main.nf
@@ -1,0 +1,66 @@
+process SEQKIT_RMDUP {
+    tag "$meta.id"
+    label 'process_low'
+    // File IO can be a bottleneck. See: https://bioinf.shenwei.me/seqkit/usage/#parallelization-of-cpu-intensive-jobs
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0':
+        'biocontainers/seqkit:2.9.0--h9ee0642_0' }"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("${prefix}.${extension}") , emit: fastx
+    tuple val(meta), path("*.log")                  , emit: log
+    path "versions.yml"                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args        = task.ext.args ?: ''
+    prefix          = task.ext.prefix ?: "${meta.id}"
+    extension       = "fastq"
+    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/ ) {
+        extension   = "fasta"
+    }
+    extension       = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    // SeqKit/rmdup takes care of compressing the output: https://bioinf.shenwei.me/seqkit/usage/#rmdup
+    if("${prefix}.${extension}" == "$fastx") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    seqkit \\
+        rmdup \\
+        --threads $task.cpus \\
+        $args \\
+        $fastx \\
+        -o ${prefix}.${extension} \\
+        2>| >(tee ${prefix}.log >&2)
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+
+    stub:
+    prefix          = task.ext.prefix ?: "${meta.id}"
+    extension       = "fastq"
+    if ("$fastx" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/ ) {
+        extension   = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    if("${prefix}.${extension}" == "$fastx") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    """
+    touch ${prefix}.${extension}
+    echo \\
+        '[INFO] 0 duplicated records removed' \\
+        > ${prefix}.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqkit/rmdup/meta.yml
+++ b/modules/nf-core/seqkit/rmdup/meta.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "seqkit_rmdup"
+description: Transforms sequences (extract ID, filter by length, remove gaps, reverse
+  complement...)
+keywords:
+  - genomics
+  - fasta
+  - fastq
+  - remove
+  - duplicates
+tools:
+  - "seqkit":
+      description: "A cross-platform and ultrafast toolkit for FASTA/Q file manipulation"
+      homepage: "https://bioinf.shenwei.me/seqkit/"
+      documentation: "https://bioinf.shenwei.me/seqkit/usage/"
+      tool_dev_url: "https://github.com/shenwei356/seqkit"
+      doi: "10.1371/journal.pone.0163962"
+      licence: ["MIT"]
+      identifier: biotools:seqkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - fastx:
+        type: file
+        description: Input fasta/fastq file
+        pattern: "*.{fsa,fas,fa,fasta,fastq,fq,fsa.gz,fas.gz,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  fastx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.${extension}:
+          type: file
+          description: Output fasta/fastq file
+          pattern: "*.{fasta,fasta.gz,fastq,fastq.gz}"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  log:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.log":
+          type: file
+          description: Log containing information regarding removed duplicates
+          pattern: "*.log"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/seqkit/rmdup/tests/main.nf.test
+++ b/modules/nf-core/seqkit/rmdup/tests/main.nf.test
@@ -1,0 +1,172 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_RMDUP"
+    script "../main.nf"
+    process "SEQKIT_RMDUP"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/rmdup"
+
+    test("sarscov2-genome_fasta") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.log[0][1]).text.contains('0 duplicated records removed') }
+            )
+        }
+
+    }
+
+    test("repeated-fasta") {
+        when {
+            process {
+                """
+                def repeated_fasta = file('repeated.fasta')
+                repeated_fasta.text = '>A\\nAGCTAGCTAGCT\\n>B\\nAGCTAGCTAGCT\\n>A\\nAGCTAGCTAGCT'
+
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    repeated_fasta
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.log[0][1]).text.contains('1 duplicated records removed') }
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.log[0][1]).text.contains('0 duplicated records removed') }
+            )
+        }
+
+    }
+
+    test("sarscov2-test_1_fastq_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.log[0][1]).text.contains('0 duplicated records removed') }
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_1' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert path(process.out.log[0][1]).text.contains('0 duplicated records removed') }
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error-stub") {
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/seqkit/rmdup/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/rmdup/tests/main.nf.test.snap
@@ -1,0 +1,247 @@
+{
+    "sarscov2-genome_fasta-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,cf833211befdf890bb6b2a3cd0b91853"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,cf833211befdf890bb6b2a3cd0b91853"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:12:04.249165"
+    },
+    "sarscov2-test_1_fastq_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:11:57.07272"
+    },
+    "sarscov2-genome_fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:11:44.13147"
+    },
+    "repeated-fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,7510a742291241e7d7556bf720caf65c"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,314c0aaef0f832a217a3f6ce3f8bc117"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,7510a742291241e7d7556bf720caf65c"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,314c0aaef0f832a217a3f6ce3f8bc117"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:11:48.203975"
+    },
+    "sarscov2-genome_fasta_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,a41135cfe024baaf42f135583fe73f0d"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9855ca606b68cb8c32718a1249488688"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:11:52.657459"
+    }
+}

--- a/modules/nf-core/seqkit/seq/environment.yml
+++ b/modules/nf-core/seqkit/seq/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqkit=2.9.0

--- a/modules/nf-core/seqkit/seq/main.nf
+++ b/modules/nf-core/seqkit/seq/main.nf
@@ -1,0 +1,67 @@
+process SEQKIT_SEQ {
+    tag "${meta.id}"
+    label 'process_low'
+    // File IO can be a bottleneck. See: https://bioinf.shenwei.me/seqkit/usage/#parallelization-of-cpu-intensive-jobs
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/seqkit:2.9.0--h9ee0642_0'
+        : 'biocontainers/seqkit:2.9.0--h9ee0642_0'}"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("${prefix}.*"), emit: fastx
+    path "versions.yml", emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/) {
+        extension = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    def call_gzip = extension.endsWith('.gz') ? "| gzip -c ${args2}" : ''
+    if ("${prefix}.${extension}" == "${fastx}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    seqkit \\
+        seq \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        ${fastx} \\
+        ${call_gzip} \\
+        > ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/) {
+        extension = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    if ("${prefix}.${extension}" == "${fastx}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    touch ${prefix}.${extension}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$(seqkit version | cut -d' ' -f2)
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqkit/seq/meta.yml
+++ b/modules/nf-core/seqkit/seq/meta.yml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "seqkit_seq"
+description: Transforms sequences (extract ID, filter by length, remove gaps, reverse
+  complement...)
+keywords:
+  - genomics
+  - fasta
+  - fastq
+  - transform
+  - filter
+  - gaps
+  - complement
+tools:
+  - "seqkit":
+      description: "A cross-platform and ultrafast toolkit for FASTA/Q file manipulation"
+      homepage: "https://bioinf.shenwei.me/seqkit/"
+      documentation: "https://bioinf.shenwei.me/seqkit/usage/"
+      tool_dev_url: "https://github.com/shenwei356/seqkit"
+      doi: "10.1371/journal.pone.0163962"
+      licence: ["MIT"]
+      identifier: biotools:seqkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - fastx:
+        type: file
+        description: Input fasta/fastq file
+        pattern: "*.{fsa,fas,fa,fasta,fastq,fq,fsa.gz,fas.gz,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  fastx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.*:
+          type: file
+          description: Output fasta/fastq file
+          pattern: "*.{fasta,fasta.gz,fastq,fastq.gz}"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test
@@ -1,0 +1,145 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_SEQ"
+    script "../main.nf"
+    process "SEQKIT_SEQ"
+    config './nextflow.config'
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/seq"
+
+    test("sarscov2-genome_fasta") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2-test_1_fastq_gz") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test_1' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+    test("sarscov2-genome_fasta-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+            )
+        }
+
+    }
+
+    test("file_name_conflict-fail_with_error-stub") {
+
+        options '-stub'
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !process.success },
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
@@ -1,0 +1,134 @@
+{
+    "sarscov2-genome_fasta-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:13:34.513457"
+    },
+    "sarscov2-test_1_fastq_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:13:27.316329"
+    },
+    "sarscov2-genome_fasta": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:13:18.463038"
+    },
+    "sarscov2-genome_fasta_gz": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ],
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,eeb475e557ef671d4b58e11f82d2448e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-01-15T15:13:22.960973"
+    }
+}

--- a/modules/nf-core/seqkit/seq/tests/nextflow.config
+++ b/modules/nf-core/seqkit/seq/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    ext.args2 = '-n'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,9 +9,14 @@
 // Global default params, used in configs
 params {
 
-    // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input = null
+
+    // QC
+    skip_preprocessing            = false
+    min_seq_length                = 30
+    max_seq_length                = 5000
+    remove_duplicates_on_sequence = false
 
     // InterProScan Options
     skip_interproscan = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -230,6 +230,38 @@
                     "description": "Display hidden parameters in the help message (only works when --help or --help_full are provided)."
                 }
             }
+        },
+        "quality_check_params": {
+            "title": "Quality check parameters",
+            "type": "object",
+            "description": "Use these parameters to control the flow of the quality check subworkflow execution.",
+            "properties": {
+                "skip_preprocessing": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-ban",
+                    "description": "Skip all default QC steps for sequences (gap trimming, length filtering, validation, duplicate removal).",
+                    "help": "Skips input amino acid sequence preprocessing transformations, length filtering, duplicate removal and validation checks."
+                },
+                "min_seq_length": {
+                    "type": "integer",
+                    "default": 30,
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "description": "The minimum allowed sequence length",
+                    "help_text": "Specify the minimum length of amino acid sequences that go into clustering."
+                },
+                "max_seq_length": {
+                    "type": "integer",
+                    "default": 5000,
+                    "fa_icon": "fas fa-ruler-horizontal",
+                    "description": "The maximum allowed sequence length",
+                    "help_text": "Specify the maximum length of amino acid sequences that go into clustering."
+                },
+                "remove_duplicates_on_sequence": {
+                    "type": "boolean",
+                    "description": "Remove duplicate input amino acid sequences, based on the sequence.",
+                    "help": "Instead of just removing by similar identifier, the tool also removes duplicate sequences."
+                }
+            }
         }
     },
     "allOf": [
@@ -244,6 +276,9 @@
         },
         {
             "$ref": "#/$defs/generic_options"
+        },
+        {
+            "$ref": "#/$defs/quality_check_params"
         }
     ]
 }

--- a/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
@@ -174,30 +174,33 @@ def validateInputSamplesheet(input) {
 // Generate methods description for MultiQC
 //
 def toolCitationText() {
+
+    def quality_check_text = [
+        "Amino acid sequence statistics were generated with SeqFu (Telatin et al. 2021).",
+        params.skip_preprocessing ? "" : "Input sequences were preprocessed with SeqKit (gap trimming, length filtering, validation, duplicate removal) (Shen et al. 2024)."
+    ].join(' ').trim()
+
+    def postprocessing_text = "Run statistics were reported using MultiQC (Ewels et al. 2016)."
+
     def citation_text = [
-        "Tools used in the workflow included:",
-        "Nextflow (Di Tommaso et al. 2017),",
-        "nf-core (Ewels et al. 2020),",
-        "Bioconda (Grüning et al. 2018),",
-        "BioContainers (da Veiga Leprevost et al. 2017),",
-        "MultiQC (Ewels et al. 2016),",
-        "SeqKit (Shen 2016),",
-        "Anaconda (Anaconda Software Distribution 2016),",
-        "Docker (Merkel 2014),",
-        "Singularity (Kurtzer et al. 2017)",
-        ".",
+        quality_check_text,
+        postprocessing_text
     ].join(' ').trim()
 
     return citation_text
 }
 
 def toolBibliographyText() {
+    def quality_check_text = [
+        '<li>Telatin, A., Fariselli, P., & Birolo, G. (2021). SeqFu: a suite of utilities for the robust and reproducible manipulation of sequence files. Bioengineering, 8(5), 59. doi: <a href="https://doi.org/10.3390/bioengineering8050059">10.3390/bioengineering8050059</a></li>',
+        params.skip_preprocessing ? '' : '<li>Shen, W., Sipos, B., & Zhao, L. (2024). SeqKit2: A Swiss army knife for sequence and alignment processing. Imeta, 3(3), e191. doi: <a href="https://doi.org/10.1002/imt2.191">10.1002/imt2.191</a></li>'
+    ].join(' ').trim()
+
+    def postprocessing_text = '<li>Ewels, P., Magnusson, M., Lundin, S., & Käller, M. (2016). MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics, 32(19), 3047–3048. doi: <a href="https://doi.org/10.1093/bioinformatics/btw354">10.1093/bioinformatics/btw354</a></li>'
+
     def reference_text = [
-        "<li>Ewels, P., Magnusson, M., Lundin, S., & Käller, M. (2016). MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics , 32(19), 3047–3048. doi: /10.1093/bioinformatics/btw354</li>",
-        "<li>Shen W, Le S, Li Y, Hu F (2016) SeqKit: A Cross-Platform and Ultrafast Toolkit for FASTA/Q File Manipulation. PLoS ONE 11(10): e0163962. doi: https://doi.org/10.1371/journal.pone.0163962</li>",
-        "<li>Anaconda Software Distribution. Computer software. Vers. 2-2.4.0. Anaconda, Nov. 2016. Web.</li>",
-        "<li>Merkel, D. (2014). Docker: lightweight linux containers for consistent development and deployment. Linux Journal, 2014(239), 2. doi: https://10.5555/2600239.2600241.</li>",
-        "<li>Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers for mobility of compute. PLoS One. 2017 May 11;12(5):e0177459. doi: https://10.1371/journal.pone.0177459. eCollection 2017. PubMed PMID: 28494014; PubMed Central PMCID: PMC5426675.</li>",
+        quality_check_text,
+        postprocessing_text
     ].join(' ').trim()
 
     return reference_text

--- a/subworkflows/nf-core/faa_seqfu_seqkit/main.nf
+++ b/subworkflows/nf-core/faa_seqfu_seqkit/main.nf
@@ -1,0 +1,42 @@
+include { SEQFU_STATS as SEQFU_STATS_BEFORE } from '../../../modules/nf-core/seqfu/stats/main'
+include { SEQKIT_SEQ                        } from '../../../modules/nf-core/seqkit/seq/main'
+include { SEQKIT_RMDUP                      } from '../../../modules/nf-core/seqkit/rmdup/main'
+include { SEQKIT_REPLACE                    } from '../../../modules/nf-core/seqkit/replace/main'
+include { SEQFU_STATS as SEQFU_STATS_AFTER  } from '../../../modules/nf-core/seqfu/stats/main'
+
+workflow FAA_SEQFU_SEQKIT {
+
+    take:
+    fasta              // tuple val(meta), path(fasta)
+    skip_preprocessing // boolean
+
+    main:
+    ch_fasta         = fasta
+    ch_multiqc_files = Channel.empty()
+    ch_versions      = Channel.empty()
+
+    SEQFU_STATS_BEFORE( ch_fasta )
+    ch_multiqc_files = ch_multiqc_files.mix( SEQFU_STATS_BEFORE.out.multiqc )
+    ch_versions      = ch_versions.mix( SEQFU_STATS_BEFORE.out.versions )
+
+    if (!skip_preprocessing) {
+        SEQKIT_SEQ( ch_fasta )
+        ch_versions = ch_versions.mix( SEQKIT_SEQ.out.versions )
+
+        SEQKIT_REPLACE( SEQKIT_SEQ.out.fastx )
+        ch_versions = ch_versions.mix( SEQKIT_REPLACE.out.versions )
+
+        SEQKIT_RMDUP( SEQKIT_REPLACE.out.fastx )
+        ch_fasta    = SEQKIT_RMDUP.out.fastx
+        ch_versions = ch_versions.mix( SEQKIT_RMDUP.out.versions )
+
+        SEQFU_STATS_AFTER( SEQKIT_RMDUP.out.fastx )
+        ch_multiqc_files = ch_multiqc_files.mix( SEQFU_STATS_AFTER.out.multiqc )
+        ch_versions      = ch_versions.mix( SEQFU_STATS_AFTER.out.versions )
+    }
+
+    emit:
+    fasta         = ch_fasta
+    multiqc_files = ch_multiqc_files
+    versions      = ch_versions
+}

--- a/subworkflows/nf-core/faa_seqfu_seqkit/meta.yml
+++ b/subworkflows/nf-core/faa_seqfu_seqkit/meta.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "faa_seqfu_seqkit"
+description: Subworkflow that checks the quality of input amino acid sequences and exports statistics
+keywords:
+  - fasta
+  - protein
+  - statistics
+  - quality check
+components:
+  - seqfu/stats
+  - seqkit/seq
+  - seqkit/rmdup
+  - seqkit/replace
+input:
+  - sequences:
+      type: file
+      description: |
+        Amino acid sequences fasta file.
+output:
+  - versions:
+      type: file
+      description: |
+        Versions file containing the software versions used in the workflow.
+  - multiqc_files:
+      type: file
+      description: |
+        Statistics file for MultiQC.
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/subworkflows/nf-core/faa_seqfu_seqkit/tests/main.nf.test
+++ b/subworkflows/nf-core/faa_seqfu_seqkit/tests/main.nf.test
@@ -1,0 +1,65 @@
+nextflow_workflow {
+
+    name "Test Subworkflow FAA_SEQFU_SEQKIT"
+    script "../main.nf"
+    workflow "FAA_SEQFU_SEQKIT"
+    config './nextflow.config'
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/faa_seqfu_seqkit"
+    tag "seqfu/stats"
+    tag "seqkit/seq"
+    tag "seqkit/rmdup"
+    tag "seqkit/replace"
+
+    test("faa") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_faa' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome_test.faa', checkIfExists: true)
+                ])
+                input[1] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("faa - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test_stub' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome_test.faa', checkIfExists: true)
+                ])
+                input[1] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out,
+                    workflow.out.versions.collect{ path(it).yaml }.unique()
+                ).match() }
+            )
+        }
+    }
+
+}

--- a/subworkflows/nf-core/faa_seqfu_seqkit/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/faa_seqfu_seqkit/tests/main.nf.test.snap
@@ -1,0 +1,167 @@
+{
+    "faa - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_after_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_before_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,4a72093d798cac55be5088015708d471",
+                    "versions.yml:md5,8412ce0c46c747dbf5a92d26ecc091ad",
+                    "versions.yml:md5,8875daf0c5eea186e4b95d77bfc12d5d",
+                    "versions.yml:md5,ae6438038b16e6e6e730325116ed2944",
+                    "versions.yml:md5,bca759d787b0ca55b454a6b0aa55f9ee"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "multiqc_files": [
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_after_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ],
+                    [
+                        {
+                            "id": "test_stub"
+                        },
+                        "test_stub_before_mqc.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,4a72093d798cac55be5088015708d471",
+                    "versions.yml:md5,8412ce0c46c747dbf5a92d26ecc091ad",
+                    "versions.yml:md5,8875daf0c5eea186e4b95d77bfc12d5d",
+                    "versions.yml:md5,ae6438038b16e6e6e730325116ed2944",
+                    "versions.yml:md5,bca759d787b0ca55b454a6b0aa55f9ee"
+                ]
+            },
+            [
+                {
+                    "FAA_SEQFU_SEQKIT:SEQFU_STATS_AFTER": {
+                        "seqfu": "1.22.3"
+                    }
+                },
+                {
+                    "FAA_SEQFU_SEQKIT:SEQKIT_SEQ": {
+                        "seqkit": "v2.9.0"
+                    }
+                },
+                {
+                    "FAA_SEQFU_SEQKIT:SEQKIT_REPLACE": {
+                        "seqkit": "2.9.0"
+                    }
+                },
+                {
+                    "FAA_SEQFU_SEQKIT:SEQFU_STATS_BEFORE": {
+                        "seqfu": "1.22.3"
+                    }
+                },
+                {
+                    "FAA_SEQFU_SEQKIT:SEQKIT_RMDUP": {
+                        "seqkit": "v2.9.0"
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-09-25T12:09:29.612482377"
+    },
+    "faa": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa.fasta:md5,242b2a540b013689b51f8814fab92817"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_after_mqc.txt:md5,e18db7ac9791039ca747e1bb45f73054"
+                    ],
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_before_mqc.txt:md5,45fdb76a36d40a331779d7591f523ed9"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,4a72093d798cac55be5088015708d471",
+                    "versions.yml:md5,8412ce0c46c747dbf5a92d26ecc091ad",
+                    "versions.yml:md5,8875daf0c5eea186e4b95d77bfc12d5d",
+                    "versions.yml:md5,ae6438038b16e6e6e730325116ed2944",
+                    "versions.yml:md5,bca759d787b0ca55b454a6b0aa55f9ee"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa.fasta:md5,242b2a540b013689b51f8814fab92817"
+                    ]
+                ],
+                "multiqc_files": [
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_after_mqc.txt:md5,e18db7ac9791039ca747e1bb45f73054"
+                    ],
+                    [
+                        {
+                            "id": "test_faa"
+                        },
+                        "test_faa_before_mqc.txt:md5,45fdb76a36d40a331779d7591f523ed9"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,4a72093d798cac55be5088015708d471",
+                    "versions.yml:md5,8412ce0c46c747dbf5a92d26ecc091ad",
+                    "versions.yml:md5,8875daf0c5eea186e4b95d77bfc12d5d",
+                    "versions.yml:md5,ae6438038b16e6e6e730325116ed2944",
+                    "versions.yml:md5,bca759d787b0ca55b454a6b0aa55f9ee"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-09-25T12:13:23.81494802"
+    }
+}

--- a/subworkflows/nf-core/faa_seqfu_seqkit/tests/nextflow.config
+++ b/subworkflows/nf-core/faa_seqfu_seqkit/tests/nextflow.config
@@ -1,0 +1,28 @@
+process {
+
+    withName: SEQFU_STATS_BEFORE {
+        ext.prefix = { "${meta.id}_before" }
+    }
+
+    withName: SEQFU_STATS_AFTER {
+        ext.prefix = { "${meta.id}_after" }
+    }
+
+    withName: SEQKIT_SEQ {
+        ext.args = [
+            "--remove-gaps",
+            "--upper-case",
+            "--validate-seq",
+            "--min-len 30",
+            "--max-len 5000"
+        ].join(' ').trim()
+        ext.prefix = "intermediate_seqkit_seq"
+    }
+
+    withName: SEQKIT_REPLACE {
+        ext.args   = '-p "/" -r "_"'
+        ext.suffix = "fasta"
+        ext.prefix = "intermediate_seqkit_replace"
+    }
+
+}

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,10 +1,10 @@
 {
     "-profile test": {
         "content": [
-            3,
+            11,
             {
-                "SEQKIT_STATS": {
-                    "seqkit": "2.9.0"
+                "SEQFU_STATS_BEFORE": {
+                    "seqfu": "1.22.3"
                 },
                 "Workflow": {
                     "nf-core/proteinannotator": "v1.0.0dev"
@@ -16,27 +16,73 @@
                 "multiqc/multiqc_data/llms-full.txt",
                 "multiqc/multiqc_data/multiqc.log",
                 "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_T1024_after.txt",
+                "multiqc/multiqc_data/multiqc_T1024_before.txt",
+                "multiqc/multiqc_data/multiqc_T1026_after.txt",
+                "multiqc/multiqc_data/multiqc_T1026_before.txt",
                 "multiqc/multiqc_data/multiqc_citations.txt",
                 "multiqc/multiqc_data/multiqc_data.json",
                 "multiqc/multiqc_data/multiqc_software_versions.txt",
                 "multiqc/multiqc_data/multiqc_sources.txt",
+                "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/pdf",
+                "multiqc/multiqc_plots/pdf/T1024_after.pdf",
+                "multiqc/multiqc_plots/pdf/T1024_before.pdf",
+                "multiqc/multiqc_plots/pdf/T1026_after.pdf",
+                "multiqc/multiqc_plots/pdf/T1026_before.pdf",
+                "multiqc/multiqc_plots/png",
+                "multiqc/multiqc_plots/png/T1024_after.png",
+                "multiqc/multiqc_plots/png/T1024_before.png",
+                "multiqc/multiqc_plots/png/T1026_after.png",
+                "multiqc/multiqc_plots/png/T1026_before.png",
+                "multiqc/multiqc_plots/svg",
+                "multiqc/multiqc_plots/svg/T1024_after.svg",
+                "multiqc/multiqc_plots/svg/T1024_before.svg",
+                "multiqc/multiqc_plots/svg/T1026_after.svg",
+                "multiqc/multiqc_plots/svg/T1026_before.svg",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",
                 "pipeline_info/nf_core_proteinannotator_software_mqc_versions.yml",
-                "seqkit",
-                "seqkit/T1024.tsv",
-                "seqkit/T1026.tsv"
+                "qc",
+                "qc/T1024",
+                "qc/T1024/T1024.fasta",
+                "qc/T1024/T1024.log",
+                "qc/T1024/T1024_after.tsv",
+                "qc/T1024/T1024_after_mqc.txt",
+                "qc/T1024/T1024_before.tsv",
+                "qc/T1024/T1024_before_mqc.txt",
+                "qc/T1026",
+                "qc/T1026/T1026.fasta",
+                "qc/T1026/T1026.log",
+                "qc/T1026/T1026_after.tsv",
+                "qc/T1026/T1026_after_mqc.txt",
+                "qc/T1026/T1026_before.tsv",
+                "qc/T1026/T1026_before_mqc.txt"
             ],
             [
+                "multiqc_T1024_after.txt:md5,f2a552d4750ff8360941b10cec141499",
+                "multiqc_T1024_before.txt:md5,f2a552d4750ff8360941b10cec141499",
+                "multiqc_T1026_after.txt:md5,aabd4e58ed67d366fd04592ca09dbc9b",
+                "multiqc_T1026_before.txt:md5,aabd4e58ed67d366fd04592ca09dbc9b",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "T1024.tsv:md5,c8a3fd71b27b9455aa837e1d50026971",
-                "T1026.tsv:md5,b028126e117cf0979b6f907cb20c6958"
+                "T1024.fasta:md5,aa546680bf58fcb8aeb10e1617e6d5bd",
+                "T1024.log:md5,a41135cfe024baaf42f135583fe73f0d",
+                "T1024_after.tsv:md5,2daf830aba484edbcf25e811f5769ad0",
+                "T1024_after_mqc.txt:md5,23c573ad96f7199ba251c7bacd1c5968",
+                "T1024_before.tsv:md5,2daf830aba484edbcf25e811f5769ad0",
+                "T1024_before_mqc.txt:md5,23c573ad96f7199ba251c7bacd1c5968",
+                "T1026.fasta:md5,ae21f6aa06d0a5cedc121db5dfc343f3",
+                "T1026.log:md5,a41135cfe024baaf42f135583fe73f0d",
+                "T1026_after.tsv:md5,052ba564eabda203298ffc26ef80b7ab",
+                "T1026_after_mqc.txt:md5,3534726223f5a24dedda4446fd202404",
+                "T1026_before.tsv:md5,052ba564eabda203298ffc26ef80b7ab",
+                "T1026_before_mqc.txt:md5,3534726223f5a24dedda4446fd202404"
             ]
         ],
         "meta": {
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-01T13:29:43.423448494"
+        "timestamp": "2025-12-01T14:53:54.397071161"
     }
 }

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -40,7 +40,7 @@ workflow PROTEINANNOTATOR {
             meta, _fasta, updated_fasta ->
             [ meta, updated_fasta ]
         }
-    ch_samplesheet_updated.view()
+
     FUNCTIONAL_ANNOTATION( ch_samplesheet_updated )
     ch_versions = ch_versions.mix( FUNCTIONAL_ANNOTATION.out.versions.first() )
 

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -3,15 +3,17 @@
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { MULTIQC } from '../modules/nf-core/multiqc/main'
-include { SEQKIT_STATS } from '../modules/nf-core/seqkit/stats/main'
-include { paramsSummaryMap } from 'plugin/nf-schema'
-include { paramsSummaryMultiqc } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { FAA_SEQFU_SEQKIT       } from '../subworkflows/nf-core/faa_seqfu_seqkit/main'
+include { FUNCTIONAL_ANNOTATION  } from '../subworkflows/local/functional_annotation'
+include { MULTIQC                } from '../modules/nf-core/multiqc/main'
+include { paramsSummaryMap       } from 'plugin/nf-schema'
+include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_proteinannotator_pipeline'
-include { FUNCTIONAL_ANNOTATION } from '../subworkflows/local/functional_annotation'
-include { MMSEQS_SEARCH } from '../modules/nf-core/mmseqs/search/main'
-include { MTMALIGN_ALIGN } from '../modules/nf-core/mtmalign/align/main'
+// TODO remove if unused
+// include { MMSEQS_SEARCH } from '../modules/nf-core/mmseqs/search/main'
+// include { MTMALIGN_ALIGN } from '../modules/nf-core/mtmalign/align/main'
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN MAIN WORKFLOW
@@ -20,29 +22,32 @@ include { MTMALIGN_ALIGN } from '../modules/nf-core/mtmalign/align/main'
 
 workflow PROTEINANNOTATOR {
     take:
-    ch_samplesheet // channel: samplesheet read in from --input
+    ch_samplesheet      // channel: samplesheet read in from --input
+    skip_preprocessing  // boolean
 
     main:
 
     ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
 
-    ch_samplesheet.view()
+    FAA_SEQFU_SEQKIT( ch_samplesheet, skip_preprocessing )
+    ch_versions = ch_versions.mix( FAA_SEQFU_SEQKIT.out.versions.first() )
 
-    FUNCTIONAL_ANNOTATION(
-        ch_samplesheet
-    )
-
-
-    // todo: move this to stats on input fasta subworkflow
-    SEQKIT_STATS(ch_samplesheet)
-    ch_versions = ch_versions.mix(SEQKIT_STATS.out.versions)
-    ch_versions = ch_versions.mix(FUNCTIONAL_ANNOTATION.out.versions.first())
+    // Replace input fasta and join back in samplesheet to ensure in sync in case of multiple sequence files
+    ch_samplesheet_updated = ch_samplesheet
+        .combine(FAA_SEQFU_SEQKIT.out.fasta, by: 0)
+        .map {
+            meta, _fasta, updated_fasta ->
+            [ meta, updated_fasta ]
+        }
+    ch_samplesheet_updated.view()
+    FUNCTIONAL_ANNOTATION( ch_samplesheet_updated )
+    ch_versions = ch_versions.mix( FUNCTIONAL_ANNOTATION.out.versions.first() )
 
     //
     // Collate and save software versions
     //
-    def topic_versions = Channel.topic("versions")
+    def topic_versions = channel.topic("versions")
         .distinct()
         .branch { entry ->
             versions_file: entry instanceof Path
@@ -99,6 +104,8 @@ workflow PROTEINANNOTATOR {
             sort: true,
         )
     )
+
+    ch_multiqc_files = ch_multiqc_files.mix(FAA_SEQFU_SEQKIT.out.multiqc_files.collect{it[1]}.ifEmpty([]))
 
     MULTIQC(
         ch_multiqc_files.collect(),


### PR DESCRIPTION
Closes #7 

Combination of `seqkit` and `seqfu` tools similar to the [proteinfamilies](https://github.com/nf-core/proteinfamilies) pipeline.

`seqfu_stats` output example:
```
File	#Seq	Total bp	Avg	N50	N75	N90	auN	Min	Max
T1024.fasta	1	408	408.00	408	408	408	408.00	408	408
```

`seqkit` pre-processing option examples (found in modules.config):
```
"--remove-gaps",
"--upper-case",
"--validate-seq",
"--min-len ${params.min_seq_length}",
"--max-len ${params.max_seq_length}"
special character replacement
duplicates removal (by id or by sequence)
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinannotator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (e.g. `nf-test test */local --profile=~test,docker` for all new local tests).
- [ ] Check for unexpected warnings in debug mode (`nf-test test */local --profile=~test,docker,debug`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
  - [ ] `docs/images/proteinannotator-metromap.light.excalidraw.png` and `docs/images/proteinannotator-metromap.light.excalidraw.png` (edit the light version only, then export and turn on dark mode) are both updated (use the excalidraw [website](https://excalidraw.com/) or [VS Code](https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor) plugin to edit)
