### PR TITLE
Add hmmsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of nf-core/proteinannotator, created with the [nf-core](https://
 
 ### `Added`
 
+- [#61](https://github.com/nf-core/proteinannotator/pull/61) - Added nf-core modules `ARIA2` and `HMMER_HMMSEARCH` to download latest Pfam HMM library (or use path to existing one) and match domains to input sequences. (by @vagkaratzas)
 - [#60](https://github.com/nf-core/proteinannotator/pull/60) - Added nf-core module `S4PRED_RUNMODEL` for secondary structure prediction (i.e., α-helix, a β-strand or a coil). (by @vagkaratzas)
 - [#59](https://github.com/nf-core/proteinannotator/pull/59) - Added nf-core qc and pre-processing subworkflow for amino acid sequences `FAA_SEQFU_SEQKIT`. (by @vagkaratzas)
 - [#57](https://github.com/nf-core/proteinannotator/pull/57) - nf-core tools template update to 3.5.1. (by @vagkaratzas)

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -18,6 +18,10 @@
 
 > Shen W, Sipos B, Zhao L. SeqKit2: A Swiss army knife for sequence and alignment processing. iMeta. 2024 Apr 5:e191. doi: 10.1002/imt2.191. PubMed PMID: 38898985; PubMed Central PMCID: PMC11183193.
 
+- [hmmer](https://pubmed.ncbi.nlm.nih.gov/29905871/)
+
+> Eddy SR. Accelerated profile HMM searches. PLoS computational biology. 2011 Oct 20;7(10):e1002195. doi: 10.1371/journal.pcbi.1002195. PubMed PMID: 22039361; PubMed Central PMCID: PMC3197634.
+
 - [InterProScan](https://academic.oup.com/bioinformatics/article/17/9/847/206564)
 
 > Zdobnov, Evgeni M., and Rolf Apweiler. “InterProScan – an Integration Platform for the Signature-Recognition Methods in InterPro.” Bioinformatics 17, no. 9 (September 1, 2001): 847–48. https://doi.org/10.1093/bioinformatics/17.9.847.

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,6 +74,14 @@ process {
         ]
     }
 
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:ARIA2' {
+        publishDir = [
+            path: { "${params.outdir}/downloaded_dbs/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:HMMER_HMMSEARCH' {
         ext.args   = { "-E ${params.hmmsearch_evalue_cutoff}" }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,6 +74,16 @@ process {
         ]
     }
 
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:HMMER_HMMSEARCH' {
+        ext.args   = { "-E ${params.hmmsearch_evalue_cutoff}" }
+        publishDir = [
+            path: { "${params.outdir}/domain_annotation/pfam/" },
+            mode: params.publish_dir_mode,
+            pattern: "*.domtbl.gz",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:S4PRED_RUNMODEL' {
         ext.prefix = { params.s4pred_outfmt }
         ext.args   = { "--outfmt ${params.s4pred_outfmt}" }

--- a/conf/test.config
+++ b/conf/test.config
@@ -24,8 +24,8 @@ params {
 
     // Input data
     input = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v1.2/samplesheet.csv'
-    // Domain annotation // TODO after figuring which test HMMs that hit to keep
-    // pfam_latest_link = params.pipelines_testdata_base_path + 'testdata/pfam/Pfam-A_test.hmm.gz'
+    // Domain annotation
+    pfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
     // Functional annotation
     skip_interproscan = true
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -23,10 +23,9 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Input data
-    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
-    // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    // From: https://github.com/nf-core/proteinfold/blob/1.1.1/conf/test.config
-    // Example: https://github.com/nf-core/test-datasets/blob/proteinfold/testdata/samplesheet/v1.2/samplesheet.csv
     input = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v1.2/samplesheet.csv'
+    // Domain annotation // TODO after figuring which test HMMs that hit to keep
+    // pfam_latest_link = params.pipelines_testdata_base_path + 'testdata/pfam/Pfam-A_test.hmm.gz'
+    // Functional annotation
     skip_interproscan = true
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,7 +15,7 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    // TODO nf-core: Specify the paths to your full test data ( on nf-core/test-datasets or directly in repositories, e.g. SRA)
-    // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input = params.pipelines_testdata_base_path + 'proteinannotator/samplesheet/snap25-isoforms.csv'
+    // Domain annotation
+    pfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -16,7 +16,11 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - [SeqFu](#seqfu) for input amino acid sequences quality check (QC)
   - [SeqKit](#seqkit) for preprocessing input amino acid sequences (i.e., gap removal, convert to upper case, validate, filter by length, replace special characters such as `/`, and remove duplicate sequences)
 
-- [Functional Annotation](#functional-annotation) Annotate proteins with functional domains
+- [Domain annotation](#domain-annotation) Annotate proteins with domains from established repositories.
+  - [aria2](#aria2) - To optionally download the latest Pfam database through the pipeline.
+  - [hmmer](#hmmer) - To optionally match the input sequence to known Pfam domains through `hmmer/hmmsearch`
+
+- [Functional annotation](#functional-annotation) Annotate proteins with functional domains
   - [InterProScan](#Interproscan) - Search the InterPro database for functional domains
 
 - [s4pred](#s4pred) - Predict secondary structures of sequences, producing per amino acid probabilities of being an α-helix, a β-strand or a coil.
@@ -60,7 +64,36 @@ The `seqkit` module is used for initial preprocessing (i.e., gap removal, conver
 
 [SeqKit](https://github.com/shenwei356/seqkit) is a cross-platform and ultrafast toolkit for FASTA/Q file manipulation.
 
-### Functional Annotation
+### Domain annotation
+
+#### aria2
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `downloaded_dbs/`
+  - `Pfam-A*.hmm.gz`: (optional) The latest full, or a minimal test, Pfam-A HMM database that can be downloaded through the pipeline.
+
+</details>
+
+[aria2](https://github.com/aria2/aria2/) is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
+
+#### hmmer
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- `domain_annotation/`
+  - `pfam/`
+    - `<samplename>.domtbl.gz`: `hmmer/hmmsearch` results along parameters info.
+
+</details>
+
+The `domain_annotation/pfam` folder contains a `.domtbl.gz` annotation file per input sample.
+
+[hmmer](https://github.com/EddyRivasLab/hmmer) is a fast and flexible alignment trimming tool that keeps phylogenetically informative sites and removes others.
+
+### Functional annotation
 
 #### InterProScan
 

--- a/main.nf
+++ b/main.nf
@@ -40,6 +40,9 @@ workflow NFCORE_PROTEINANNOTATOR {
     PROTEINANNOTATOR (
         samplesheet,
         params.skip_preprocessing,
+        params.skip_pfam,
+        params.pfam_latest_link,
+        params.pfam_db,
         params.skip_s4pred
     )
     emit:

--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,16 @@
         "https://github.com/nf-core/modules.git": {
             "modules": {
                 "nf-core": {
+                    "aria2": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
+                    "hmmer/hmmsearch": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
+                    },
                     "mmseqs/search": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",

--- a/modules/nf-core/aria2/environment.yml
+++ b/modules/nf-core/aria2/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::aria2=1.36.0

--- a/modules/nf-core/aria2/main.nf
+++ b/modules/nf-core/aria2/main.nf
@@ -1,0 +1,47 @@
+process ARIA2 {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/aria2:1.36.0' :
+        'biocontainers/aria2:1.36.0' }"
+
+    input:
+    tuple val(meta), val(source_url)
+
+    output:
+    tuple val(meta), path("$downloaded_file"), emit: downloaded_file
+    path "versions.yml"                      , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args        = task.ext.args ?: ''
+    downloaded_file = source_url.split("/")[-1]
+
+    """
+    aria2c \\
+        --check-certificate=false \\
+        ${args} \\
+        ${source_url}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        aria2: \$(echo \$(aria2c --version 2>&1) | grep 'aria2 version' | cut -f3 -d ' ')
+    END_VERSIONS
+    """
+
+    stub:
+    downloaded_file = source_url.split("/")[-1]
+
+    """
+    touch ${downloaded_file}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        aria2: \$(echo \$(aria2c --version 2>&1) | grep 'aria2 version' | cut -f3 -d ' ')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/aria2/meta.yml
+++ b/modules/nf-core/aria2/meta.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+name: "aria2"
+description: CLI Download utility
+keywords:
+  - download
+  - utility
+  - http(s)
+tools:
+  - "aria2":
+      description: "aria2 is a lightweight multi-protocol & multi-source, cross platform
+        download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP,
+        BitTorrent and Metalink."
+      homepage: "https://aria2.github.io/"
+      documentation: "https://aria2.github.io/manual/en/html/index.html"
+      tool_dev_url: "https://github.com/aria2/aria2/"
+      licence: ["GPL v2"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'test', single_end:false ]`
+    - source_url:
+        type: string
+        description: Source URL to be downloaded
+        pattern: "{http,https}*"
+        ontologies:
+          - edam: "http://edamontology.org/data_1052" # URL
+output:
+  downloaded_file:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - $downloaded_file:
+          type: file
+          description: Downloaded file from source
+          pattern: "*.*"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: "http://edamontology.org/format_3750" # YAML
+authors:
+  - "@JoseEspinosa"
+  - "@leoisl"
+maintainers:
+  - "@JoseEspinosa"
+  - "@leoisl"

--- a/modules/nf-core/aria2/tests/main.nf.test
+++ b/modules/nf-core/aria2/tests/main.nf.test
@@ -1,0 +1,45 @@
+nextflow_process {
+    name "Test Process ARIA2"
+    script "../main.nf"
+    process "ARIA2"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "aria2"
+
+    test("sarscov2 Illumina single end [bam]") {
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test' ], // meta map
+                             params.test_data['sarscov2']['illumina']['test_single_end_bam']  // https URL
+                           ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 Illumina single end [bam] - stub") {
+        options "-stub-run"
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test' ], // meta map
+                             params.test_data['sarscov2']['illumina']['test_single_end_bam']  // https URL
+                           ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/aria2/tests/main.nf.test.snap
+++ b/modules/nf-core/aria2/tests/main.nf.test.snap
@@ -1,0 +1,60 @@
+{
+    "sarscov2 Illumina single end [bam] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.single_end.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,1d3d763f0ff390b632205a498112b076"
+                ],
+                "downloaded_file": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.single_end.bam:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,1d3d763f0ff390b632205a498112b076"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-14T17:34:30.569759"
+    },
+    "sarscov2 Illumina single end [bam]": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.single_end.bam:md5,21afed4c3e007de5e007cc5cbaebede7"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,1d3d763f0ff390b632205a498112b076"
+                ],
+                "downloaded_file": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.single_end.bam:md5,21afed4c3e007de5e007cc5cbaebede7"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,1d3d763f0ff390b632205a498112b076"
+                ]
+            }
+        ],
+        "timestamp": "2023-12-14T17:34:22.216677"
+    }
+}

--- a/modules/nf-core/hmmer/hmmsearch/environment.yml
+++ b/modules/nf-core/hmmer/hmmsearch/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::hmmer=3.4

--- a/modules/nf-core/hmmer/hmmsearch/main.nf
+++ b/modules/nf-core/hmmer/hmmsearch/main.nf
@@ -1,0 +1,70 @@
+process HMMER_HMMSEARCH {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/hmmer:3.4--hdbdd923_1' :
+        'biocontainers/hmmer:3.4--hdbdd923_1' }"
+
+    input:
+    tuple val(meta), path(hmmfile), path(seqdb), val(write_align), val(write_target), val(write_domain)
+
+    output:
+    tuple val(meta), path('*.txt.gz')   , emit: output
+    tuple val(meta), path('*.sto.gz')   , emit: alignments    , optional: true
+    tuple val(meta), path('*.tbl.gz')   , emit: target_summary, optional: true
+    tuple val(meta), path('*.domtbl.gz'), emit: domain_summary, optional: true
+    path "versions.yml"                 , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args       = task.ext.args   ?: ''
+    def prefix     = task.ext.prefix ?: "${meta.id}"
+    output         = "${prefix}.txt"
+    alignment      = write_align     ? "-A ${prefix}.sto" : ''
+    target_summary = write_target    ? "--tblout ${prefix}.tbl" : ''
+    domain_summary = write_domain    ? "--domtblout ${prefix}.domtbl" : ''
+    """
+    hmmsearch \\
+        $args \\
+        --cpu $task.cpus \\
+        -o $output \\
+        $alignment \\
+        $target_summary \\
+        $domain_summary \\
+        $hmmfile \\
+        $seqdb
+
+    gzip --no-name *.txt \\
+        ${write_align ? '*.sto' : ''} \\
+        ${write_target ? '*.tbl' : ''} \\
+        ${write_domain ? '*.domtbl' : ''}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmer: \$(hmmsearch -h | grep -o '^# HMMER [0-9.]*' | sed 's/^# HMMER *//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch "${prefix}.txt"
+    ${write_align ? "touch ${prefix}.sto" : ''} \\
+    ${write_target ? "touch ${prefix}.tbl" : ''} \\
+    ${write_domain ? "touch ${prefix}.domtbl" : ''}
+
+    gzip --no-name *.txt \\
+        ${write_align ? '*.sto' : ''} \\
+        ${write_target ? '*.tbl' : ''} \\
+        ${write_domain ? '*.domtbl' : ''}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        hmmer: \$(hmmsearch -h | grep -o '^# HMMER [0-9.]*' | sed 's/^# HMMER *//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/hmmer/hmmsearch/meta.yml
+++ b/modules/nf-core/hmmer/hmmsearch/meta.yml
@@ -1,0 +1,100 @@
+name: hmmer_hmmsearch
+description: search profile(s) against a sequence database
+keywords:
+  - Hidden Markov Model
+  - HMM
+  - hmmer
+  - hmmsearch
+tools:
+  - hmmer:
+      description: Biosequence analysis using profile hidden Markov models
+      homepage: http://hmmer.org/
+      documentation: http://hmmer.org/documentation.html
+      tool_dev_url: https://github.com/EddyRivasLab/hmmer
+      doi: "10.1371/journal.pcbi.1002195"
+      licence: ["BSD"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - hmmfile:
+        type: file
+        description: One or more HMM profiles created with hmmbuild
+        pattern: "*.{hmm,hmm.gz}"
+        ontologies: []
+    - seqdb:
+        type: file
+        description: Database of sequences in FASTA format
+        pattern: "*.{fasta,fna,faa,fa,fasta.gz,fna.gz,faa.gz,fa.gz}"
+        ontologies: []
+    - write_align:
+        type: boolean
+        description: Flag to save optional alignment output. Specify with 'true' to
+          save.
+    - write_target:
+        type: boolean
+        description: Flag to save optional per target summary. Specify with 'true' to
+          save.
+    - write_domain:
+        type: boolean
+        description: Flag to save optional per domain summary. Specify with 'true' to
+          save.
+output:
+  output:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.txt.gz":
+          type: file
+          description: Human readable output summarizing hmmsearch results
+          pattern: "*.{txt.gz}"
+          ontologies: []
+  alignments:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.sto.gz":
+          type: file
+          description: Optional multiple sequence alignment (MSA) in Stockholm format
+          pattern: "*.{sto.gz}"
+          ontologies: []
+  target_summary:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.tbl.gz":
+          type: file
+          description: Optional tabular (space-delimited) summary of per-target output
+          pattern: "*.{tbl.gz}"
+          ontologies: []
+  domain_summary:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.domtbl.gz":
+          type: file
+          description: Optional tabular (space-delimited) summary of per-domain output
+          pattern: "*.{domtbl.gz}"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@Midnighter"
+maintainers:
+  - "@Midnighter"

--- a/modules/nf-core/hmmer/hmmsearch/tests/main.nf.test
+++ b/modules/nf-core/hmmer/hmmsearch/tests/main.nf.test
@@ -1,0 +1,126 @@
+nextflow_process {
+
+    name "Test Process HMMER_HMMSEARCH"
+    script "../main.nf"
+    process "HMMER_HMMSEARCH"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "hmmer"
+    tag "hmmer/hmmsearch"
+
+    test("hmmer/hmmsearch") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/e_coli_k12_16s.fna.gz', checkIfExists: true),
+                    false,
+                    false,
+                    false
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.output[0][1]).linesGzip.toString().contains('[ok]') },
+                { assert snapshot(process.out.versions).match() }
+            )
+        }
+
+    }
+
+    test("hmmer/hmmsearch - optional") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/e_coli_k12_16s.fna.gz', checkIfExists: true),
+                    true,
+                    true,
+                    true
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.output.get(0).get(1)).linesGzip.toString().contains('[ok]') },
+                { assert path(process.out.target_summary.get(0).get(1)).linesGzip.toString().contains('[ok]') },
+                { assert snapshot(
+                    process.out.alignments +
+                    process.out.versions
+                ).match() }
+            )
+        }
+
+    }
+
+    test("hmmer/hmmsearch - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/e_coli_k12_16s.fna.gz', checkIfExists: true),
+                    false,
+                    false,
+                    false
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("hmmer/hmmsearch - optional - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/bac.16S_rRNA.hmm.gz', checkIfExists: true),
+                    file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/hmmer/e_coli_k12_16s.fna.gz', checkIfExists: true),
+                    true,
+                    true,
+                    true
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/hmmer/hmmsearch/tests/main.nf.test.snap
+++ b/modules/nf-core/hmmer/hmmsearch/tests/main.nf.test.snap
@@ -1,0 +1,175 @@
+{
+    "hmmer/hmmsearch": {
+        "content": [
+            [
+                "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-28T12:18:47.293093635"
+    },
+    "hmmer/hmmsearch - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+                ],
+                "alignments": [
+                    
+                ],
+                "domain_summary": [
+                    
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "target_summary": [
+                    
+                ],
+                "versions": [
+                    "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-28T12:18:57.862047944"
+    },
+    "hmmer/hmmsearch - optional - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.sto.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+                ],
+                "alignments": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.sto.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "domain_summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.txt.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "target_summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.tbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-28T12:19:03.49192788"
+    },
+    "hmmer/hmmsearch - optional": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.sto.gz:md5,5c44c289b9e36aa1f7f3afae2005fbb7"
+                ],
+                "versions.yml:md5,37393b1da5a14113d3290ab8b3b4c40f"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-03-28T12:18:52.725638562"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,12 @@ params {
     max_seq_length                = 5000
     remove_duplicates_on_sequence = false
 
+    // Domain annotation
+    skip_pfam               = false
+    pfam_db                 = null
+    pfam_latest_link        = "https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz"
+    hmmsearch_evalue_cutoff = 0.001
+
     // InterProScan Options
     skip_interproscan = false
     interproscan_tar_gz = "https://ftp.ebi.ac.uk/pub/software/unix/iprscan/5/5.74-105.0/interproscan-5.74-105.0-64-bit.tar.gz"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -276,6 +276,7 @@
                 },
                 "pfam_db": {
                     "type": "string",
+                    "format": "file-path",
                     "description": "Path to an already installed Pfam HMM database (.hmm.gz).",
                     "help_text": "If left null and skip_pfam is false, the pipeline will start downloading the latest Pfam HMM library."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -263,6 +263,35 @@
                 }
             }
         },
+        "domain_annotation_params": {
+            "title": "Domain annotation parameters",
+            "type": "object",
+            "description": "Use these parameters to control the flow of the domain annotation execution.",
+            "properties": {
+                "skip_pfam": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-ban",
+                    "description": "Skip the domain annotation with the Pfam database.",
+                    "help": "Skips the domain annotation of input sequence against a Pfam database."
+                },
+                "pfam_db": {
+                    "type": "string",
+                    "description": "Path to an already installed Pfam HMM database (.hmm.gz).",
+                    "help_text": "If left null and skip_pfam is false, the pipeline will start downloading the latest Pfam HMM library."
+                },
+                "pfam_latest_link": {
+                    "type": "string",
+                    "default": "https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz",
+                    "description": "InterPro hosted link to the latest Pfam HMM database file.",
+                    "help_text": "Latest version should be a bit more than 350MB."
+                },
+                "hmmsearch_evalue_cutoff": {
+                    "type": "number",
+                    "default": 0.001,
+                    "description": "hmmsearch e-value cutoff threshold for reported results"
+                }
+            }
+        },
         "prediction_params": {
             "title": "Prediction parameters",
             "type": "object",
@@ -299,6 +328,9 @@
         },
         {
             "$ref": "#/$defs/quality_check_params"
+        },
+        {
+            "$ref": "#/$defs/domain_annotation_params"
         },
         {
             "$ref": "#/$defs/prediction_params"

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -26,7 +26,7 @@ workflow DOMAIN_ANNOTATION {
             .map{ meta, seqs, _meta2, models -> [meta, models, seqs, false, false, true] }
 
         HMMER_HMMSEARCH( ch_input_for_hmmsearch )
-        ch_versions = ch_versions.mix( HMMER_HMMSEARCH.out.versions )
+        ch_versions = ch_versions.mix( HMMER_HMMSEARCH.out.versions.first() )
     }
 
     emit:

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -1,0 +1,35 @@
+include { ARIA2           } from '../../../modules/nf-core/aria2/main'
+include { HMMER_HMMSEARCH } from '../../../modules/nf-core/hmmer/hmmsearch/main'
+
+workflow DOMAIN_ANNOTATION {
+    take:
+    ch_fasta          // channel: [ val(meta), [ fasta ] ]
+    skip_pfam         // boolean
+    pfam_latest_link  // string, path to the latest pfam HMM database, to download
+    pfam_db           // string, path to the pfam HMM database, if already exists
+
+    main:
+
+    ch_versions = channel.empty()
+
+    if (!skip_pfam) {
+        if (!pfam_db) {
+            ch_pfam_link = channel.of([ [ id: 'pfam' ], pfam_latest_link ])
+
+            ARIA2( ch_pfam_link )
+            ch_versions = ch_versions.mix( ARIA2.out.versions )
+            pfam_db = ARIA2.out.downloaded_file
+        }
+
+        ch_input_for_hmmsearch = ch_fasta
+            .combine(pfam_db)
+            .map{ meta, seqs, _meta2, models -> [meta, models, seqs, false, false, true] }
+
+        HMMER_HMMSEARCH( ch_input_for_hmmsearch )
+        ch_versions = ch_versions.mix( HMMER_HMMSEARCH.out.versions )
+    }
+
+    emit:
+    pfam_domains = HMMER_HMMSEARCH.out.domain_summary
+    versions     = ch_versions
+}

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -18,11 +18,13 @@ workflow DOMAIN_ANNOTATION {
 
             ARIA2( ch_pfam_link )
             ch_versions = ch_versions.mix( ARIA2.out.versions )
-            pfam_db = ARIA2.out.downloaded_file
+            ch_pfam_db = ARIA2.out.downloaded_file
+        } else {
+            ch_pfam_db = channel.of([ [ id: 'pfam' ], pfam_db ])
         }
 
         ch_input_for_hmmsearch = ch_fasta
-            .combine(pfam_db)
+            .combine(ch_pfam_db)
             .map{ meta, seqs, _meta2, models -> [meta, models, seqs, false, false, true] }
 
         HMMER_HMMSEARCH( ch_input_for_hmmsearch )

--- a/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
@@ -180,12 +180,15 @@ def toolCitationText() {
         params.skip_preprocessing ? "" : "Input sequences were preprocessed with SeqKit (gap trimming, length filtering, validation, duplicate removal) (Shen et al. 2024)."
     ].join(' ').trim()
 
+    def domain_annotation_text = params.skip_pfam ? "" : "Pfam domains were searched with hmmer/hmmsearch (Eddy et al. 2011)."
+
     def prediction_text = params.skip_s4pred ? "" : "Secondary structures were predicted via the s4pred software (Moffat et al. 2021)."
 
     def postprocessing_text = "Run statistics were reported using MultiQC (Ewels et al. 2016)."
 
     def citation_text = [
         quality_check_text,
+        domain_annotation_text,
         prediction_text,
         postprocessing_text
     ].join(' ').trim()
@@ -199,12 +202,15 @@ def toolBibliographyText() {
         params.skip_preprocessing ? '' : '<li>Shen, W., Sipos, B., & Zhao, L. (2024). SeqKit2: A Swiss army knife for sequence and alignment processing. Imeta, 3(3), e191. doi: <a href="https://doi.org/10.1002/imt2.191">10.1002/imt2.191</a></li>'
     ].join(' ').trim()
 
+    def domain_annotation_text = params.skip_pfam ? '' : '<li>Eddy, S. R. (2011). Accelerated profile HMM searches. PLoS computational biology, 7(10), e1002195. doi: <a href="https://doi.org/10.1371/journal.pcbi.1002195">10.1371/journal.pcbi.1002195</a></li>'
+
     def prediction_text = params.skip_s4pred ? '' : '<li>Moffat, L., & Jones, D. T. (2021). Increasing the accuracy of single sequence prediction methods using a deep semi-supervised learning framework. Bioinformatics, 37(21), 3744-3751. doi: <a href="https://doi.org/10.1093/bioinformatics/btab491">10.1093/bioinformatics/btab491</a></li>'
 
     def postprocessing_text = '<li>Ewels, P., Magnusson, M., Lundin, S., & Käller, M. (2016). MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics, 32(19), 3047–3048. doi: <a href="https://doi.org/10.1093/bioinformatics/btw354">10.1093/bioinformatics/btw354</a></li>'
 
     def reference_text = [
         quality_check_text,
+        domain_annotation_text,
         prediction_text,
         postprocessing_text
     ].join(' ').trim()

--- a/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
@@ -180,7 +180,7 @@ def toolCitationText() {
         params.skip_preprocessing ? "" : "Input sequences were preprocessed with SeqKit (gap trimming, length filtering, validation, duplicate removal) (Shen et al. 2024)."
     ].join(' ').trim()
 
-    def domain_annotation_text = params.skip_pfam ? "" : "Pfam domains were searched with hmmer/hmmsearch (Eddy et al. 2011)."
+    def domain_annotation_text = params.skip_pfam ? "" : "Pfam domains were annotated with hmmer/hmmsearch (Eddy et al. 2011)."
 
     def prediction_text = params.skip_s4pred ? "" : "Secondary structures were predicted via the s4pred software (Moffat et al. 2021)."
 

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -8,3 +8,5 @@ multiqc/multiqc_data/llms-full.txt
 multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 pipeline_info/*.{html,json,txt,yml}
+domain_annotation/pfam/T1024.domtbl.gz
+domain_annotation/pfam/T1026.domtbl.gz

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,19 +1,43 @@
 {
     "-profile test": {
         "content": [
-            13,
+            16,
             {
+                "ARIA2": {
+                    "aria2": "1.36.0"
+                },
+                "HMMER_HMMSEARCH": {
+                    "hmmer": 3.4
+                },
                 "S4PRED_RUNMODEL": {
                     "s4pred": "1.2.1"
                 },
+                "SEQFU_STATS_AFTER": {
+                    "seqfu": "1.22.3"
+                },
                 "SEQFU_STATS_BEFORE": {
                     "seqfu": "1.22.3"
+                },
+                "SEQKIT_REPLACE": {
+                    "seqkit": "2.9.0"
+                },
+                "SEQKIT_RMDUP": {
+                    "seqkit": "v2.9.0"
+                },
+                "SEQKIT_SEQ": {
+                    "seqkit": "v2.9.0"
                 },
                 "Workflow": {
                     "nf-core/proteinannotator": "v1.0.0dev"
                 }
             },
             [
+                "domain_annotation",
+                "domain_annotation/pfam",
+                "domain_annotation/pfam/T1024.domtbl.gz",
+                "domain_annotation/pfam/T1026.domtbl.gz",
+                "downloaded_dbs",
+                "downloaded_dbs/Pfam-A_test.hmm.gz",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -70,6 +94,7 @@
                 "s4pred/T1026/ss2/T1026.ss2"
             ],
             [
+                "Pfam-A_test.hmm.gz:md5,a5ab72b2b7bc72c62756684707e2387c",
                 "multiqc_T1024_after.txt:md5,f2a552d4750ff8360941b10cec141499",
                 "multiqc_T1024_before.txt:md5,f2a552d4750ff8360941b10cec141499",
                 "multiqc_T1026_after.txt:md5,aabd4e58ed67d366fd04592ca09dbc9b",
@@ -95,6 +120,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-02T10:01:13.30875032"
+        "timestamp": "2025-12-02T15:47:22.509332504"
     }
 }

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -4,6 +4,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 include { FAA_SEQFU_SEQKIT       } from '../subworkflows/nf-core/faa_seqfu_seqkit/main'
+include { DOMAIN_ANNOTATION      } from '../subworkflows/local/domain_annotation'
 include { FUNCTIONAL_ANNOTATION  } from '../subworkflows/local/functional_annotation'
 include { S4PRED_RUNMODEL        } from '../modules/nf-core/s4pred/runmodel/main'
 include { MULTIQC                } from '../modules/nf-core/multiqc/main'
@@ -25,6 +26,9 @@ workflow PROTEINANNOTATOR {
     take:
     ch_samplesheet      // channel: samplesheet read in from --input
     skip_preprocessing  // boolean
+    skip_pfam           // boolean
+    pfam_latest_link    // string, path to the latest pfam HMM database, to download
+    pfam_db             // string, path to the pfam HMM database, if already exists
     skip_s4pred         // boolean
 
     main:
@@ -42,6 +46,9 @@ workflow PROTEINANNOTATOR {
             meta, _fasta, updated_fasta ->
             [ meta, updated_fasta ]
         }
+
+    DOMAIN_ANNOTATION( ch_samplesheet_updated, skip_pfam, pfam_latest_link, pfam_db )
+    ch_versions = ch_versions.mix( DOMAIN_ANNOTATION.out.versions.first() )
 
     FUNCTIONAL_ANNOTATION( ch_samplesheet_updated )
     ch_versions = ch_versions.mix( FUNCTIONAL_ANNOTATION.out.versions.first() )

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -37,7 +37,7 @@ workflow PROTEINANNOTATOR {
     ch_multiqc_files = channel.empty()
 
     FAA_SEQFU_SEQKIT( ch_samplesheet, skip_preprocessing )
-    ch_versions = ch_versions.mix( FAA_SEQFU_SEQKIT.out.versions.first() )
+    ch_versions = ch_versions.mix( FAA_SEQFU_SEQKIT.out.versions )
 
     // Replace input fasta and join back in samplesheet to ensure in sync in case of multiple sequence files
     ch_samplesheet_updated = ch_samplesheet
@@ -48,10 +48,10 @@ workflow PROTEINANNOTATOR {
         }
 
     DOMAIN_ANNOTATION( ch_samplesheet_updated, skip_pfam, pfam_latest_link, pfam_db )
-    ch_versions = ch_versions.mix( DOMAIN_ANNOTATION.out.versions.first() )
+    ch_versions = ch_versions.mix( DOMAIN_ANNOTATION.out.versions )
 
     FUNCTIONAL_ANNOTATION( ch_samplesheet_updated )
-    ch_versions = ch_versions.mix( FUNCTIONAL_ANNOTATION.out.versions.first() )
+    ch_versions = ch_versions.mix( FUNCTIONAL_ANNOTATION.out.versions )
 
     if (!skip_s4pred) {
         S4PRED_RUNMODEL( ch_samplesheet_updated )


### PR DESCRIPTION
Closes #30 and #40 

Added nf-core modules `ARIA2` and `HMMER_HMMSEARCH` to download latest Pfam HMM library (or use path to existing one) and match domains to input sequences.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/proteinannotator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (e.g. `nf-test test */local --profile=~test,docker` for all new local tests).
- [ ] Check for unexpected warnings in debug mode (`nf-test test */local --profile=~test,docker,debug`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
  - [ ] `docs/images/proteinannotator-metromap.light.excalidraw.png` and `docs/images/proteinannotator-metromap.light.excalidraw.png` (edit the light version only, then export and turn on dark mode) are both updated (use the excalidraw [website](https://excalidraw.com/) or [VS Code](https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor) plugin to edit)
