### PR TITLE
Download and hmmsearch FunFam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial release of nf-core/proteinannotator, created with the [nf-core](https://
 
 ### `Added`
 
+- [#62](https://github.com/nf-core/proteinannotator/pull/62) - Added the option to download and use the latest FunFam HMM library (or use path to an existing one) for domain annotation. (by @vagkaratzas)
 - [#61](https://github.com/nf-core/proteinannotator/pull/61) - Added nf-core modules `ARIA2` and `HMMER_HMMSEARCH` to download latest Pfam HMM library (or use path to existing one) and match domains to input sequences. (by @vagkaratzas)
 - [#60](https://github.com/nf-core/proteinannotator/pull/60) - Added nf-core module `S4PRED_RUNMODEL` for secondary structure prediction (i.e., α-helix, a β-strand or a coil). (by @vagkaratzas)
 - [#59](https://github.com/nf-core/proteinannotator/pull/59) - Added nf-core qc and pre-processing subworkflow for amino acid sequences `FAA_SEQFU_SEQKIT`. (by @vagkaratzas)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,7 +74,7 @@ process {
         ]
     }
 
-    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:ARIA2' {
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:ARIA2_PFAM' {
         publishDir = [
             path: { "${params.outdir}/downloaded_dbs/" },
             mode: params.publish_dir_mode,
@@ -82,10 +82,28 @@ process {
         ]
     }
 
-    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:HMMER_HMMSEARCH' {
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:ARIA2_FUNFAM' {
+        publishDir = [
+            path: { "${params.outdir}/downloaded_dbs/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:HMMSEARCH_PFAM' {
         ext.args   = { "-E ${params.hmmsearch_evalue_cutoff}" }
         publishDir = [
             path: { "${params.outdir}/domain_annotation/pfam/" },
+            mode: params.publish_dir_mode,
+            pattern: "*.domtbl.gz",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'NFCORE_PROTEINANNOTATOR:PROTEINANNOTATOR:DOMAIN_ANNOTATION:HMMSEARCH_FUNFAM' {
+        ext.args   = { "-E ${params.hmmsearch_evalue_cutoff}" }
+        publishDir = [
+            path: { "${params.outdir}/domain_annotation/funfam/" },
             mode: params.publish_dir_mode,
             pattern: "*.domtbl.gz",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }

--- a/conf/test.config
+++ b/conf/test.config
@@ -25,7 +25,8 @@ params {
     // Input data
     input = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v1.2/samplesheet.csv'
     // Domain annotation
-    pfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
+    pfam_latest_link   = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
+    funfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/funfam/funfam-hmm3-v4_3_0_test.lib.gz'
     // Functional annotation
     skip_interproscan = true
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,5 +17,6 @@ params {
     // Input data for full size test
     input = params.pipelines_testdata_base_path + 'proteinannotator/samplesheet/snap25-isoforms.csv'
     // Domain annotation
-    pfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
+    pfam_latest_link   = params.pipelines_testdata_base_path + 'proteinannotator/testdata/pfam/Pfam-A_test.hmm.gz'
+    funfam_latest_link = params.pipelines_testdata_base_path + 'proteinannotator/testdata/funfam/funfam-hmm3-v4_3_0_test.lib.gz'
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -6,8 +6,6 @@ This document describes the output produced by the pipeline. Most of the plots a
 
 The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
 
-<!-- TODO nf-core: Write this documentation describing your workflow's output -->
-
 ## Pipeline overview
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
@@ -17,8 +15,8 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - [SeqKit](#seqkit) for preprocessing input amino acid sequences (i.e., gap removal, convert to upper case, validate, filter by length, replace special characters such as `/`, and remove duplicate sequences)
 
 - [Domain annotation](#domain-annotation) Annotate proteins with domains from established repositories.
-  - [aria2](#aria2) - To optionally download the latest Pfam database through the pipeline.
-  - [hmmer](#hmmer) - To optionally match the input sequence to known Pfam domains through `hmmer/hmmsearch`
+  - [aria2](#aria2) - To optionally download the latest Pfam and/or FunFam databases through the pipeline.
+  - [hmmer](#hmmer) - To optionally match the input sequence to known Pfam and/or FunFam domains through `hmmer/hmmsearch`
 
 - [Functional annotation](#functional-annotation) Annotate proteins with functional domains
   - [InterProScan](#Interproscan) - Search the InterPro database for functional domains
@@ -73,8 +71,11 @@ The `seqkit` module is used for initial preprocessing (i.e., gap removal, conver
 
 - `downloaded_dbs/`
   - `Pfam-A*.hmm.gz`: (optional) The latest full, or a minimal test, Pfam-A HMM database that can be downloaded through the pipeline.
+  - `funfam-hmm3-v4_3_0*.lib.gz`: (optional) The latest (v4_3_0) full, or a minimal test, FunFam HMM database that can be downloaded through the pipeline.
 
 </details>
+
+If the `skip_*` flags (e.g., `skip_pfam`, `skip_funfam`) for each domain annotation database is set to `true`, or the `*_db` parameter paths (e.g., `pfam_db`, `funfam_db`) are set (i.e., not `null`), or the run is resumed after a successful database download, then the respective database will not be (re)downloaded. The full database links can be found in the main `nextflow.config` file, while minimal test versions can be found in the `test` and `test_full` profiles (i.e., `conf/test.config`, `conf/test_full.config`).
 
 [aria2](https://github.com/aria2/aria2/) is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.
 
@@ -86,10 +87,12 @@ The `seqkit` module is used for initial preprocessing (i.e., gap removal, conver
 - `domain_annotation/`
   - `pfam/`
     - `<samplename>.domtbl.gz`: `hmmer/hmmsearch` results along parameters info.
+  - `funfam/`
+    - `<samplename>.domtbl.gz`: `hmmer/hmmsearch` results along parameters info.
 
 </details>
 
-The `domain_annotation/pfam` folder contains a `.domtbl.gz` annotation file per input sample.
+Each of the `domain_annotation/` subfolders (e.g., `pfam`, `funfam`) contain a `.domtbl.gz` annotation file per input sample, depending on which domain annotation databases were used in the pipeline execution.
 
 [hmmer](https://github.com/EddyRivasLab/hmmer) is a fast and flexible alignment trimming tool that keeps phylogenetically informative sites and removes others.
 

--- a/main.nf
+++ b/main.nf
@@ -41,11 +41,11 @@ workflow NFCORE_PROTEINANNOTATOR {
         samplesheet,
         params.skip_preprocessing,
         params.skip_pfam,
-        params.pfam_latest_link,
         params.pfam_db,
+        params.pfam_latest_link,
         params.skip_funfam,
-        params.funfam_latest_link,
         params.funfam_db,
+        params.funfam_latest_link,
         params.skip_s4pred
     )
     emit:

--- a/main.nf
+++ b/main.nf
@@ -43,6 +43,9 @@ workflow NFCORE_PROTEINANNOTATOR {
         params.skip_pfam,
         params.pfam_latest_link,
         params.pfam_db,
+        params.skip_funfam,
+        params.funfam_latest_link,
+        params.funfam_db,
         params.skip_s4pred
     )
     emit:

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,9 @@ params {
     skip_pfam               = false
     pfam_db                 = null
     pfam_latest_link        = "https://ftp.ebi.ac.uk/pub/databases/Pfam/current_release/Pfam-A.hmm.gz"
+    skip_funfam             = false
+    funfam_db               = null
+    funfam_latest_link      = "https://download.cathdb.info/cath/releases/all-releases/v4_3_0/sequence-data/funfam-hmm3-v4_3_0.lib.gz"
     hmmsearch_evalue_cutoff = 0.001
 
     // InterProScan Options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -286,6 +286,23 @@
                     "description": "InterPro hosted link to the latest Pfam HMM database file.",
                     "help_text": "Latest version should be a bit more than 350MB."
                 },
+                "skip_funfam": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-ban",
+                    "description": "Skip the domain annotation with the FunFam database.",
+                    "help": "Skips the domain annotation of input sequence against a FunFam database."
+                },
+                "funfam_db": {
+                    "type": "string",
+                    "format": "file-path",
+                    "description": "Path to an already installed FunFam HMM database (.lib.gz).",
+                    "help_text": "If left null and skip_funfam is false, the pipeline will start downloading the latest FunFam HMM library."
+                },
+                "funfam_latest_link": {
+                    "type": "string",
+                    "default": "https://download.cathdb.info/cath/releases/all-releases/v4_3_0/sequence-data/funfam-hmm3-v4_3_0.lib.gz",
+                    "description": "CATH hosted link to the latest available (v4_3_0) FunFam HMM database file."
+                },
                 "hmmsearch_evalue_cutoff": {
                     "type": "number",
                     "default": 0.001,

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -1,4 +1,5 @@
-include { ARIA2                               } from '../../../modules/nf-core/aria2/main'
+include { ARIA2 as ARIA2_PFAM                 } from '../../../modules/nf-core/aria2/main'
+include { ARIA2 as ARIA2_FUNFAM               } from '../../../modules/nf-core/aria2/main'
 include { HMMER_HMMSEARCH as HMMSEARCH_PFAM   } from '../../../modules/nf-core/hmmer/hmmsearch/main'
 include { HMMER_HMMSEARCH as HMMSEARCH_FUNFAM } from '../../../modules/nf-core/hmmer/hmmsearch/main'
 
@@ -14,15 +15,17 @@ workflow DOMAIN_ANNOTATION {
 
     main:
 
-    ch_versions = channel.empty()
+    ch_versions       = channel.empty()
+    ch_pfam_domains   = channel.empty()
+    ch_funfam_domains = channel.empty()
 
     if (!skip_pfam) {
         if (!pfam_db) {
             ch_pfam_link = channel.of([ [ id: 'pfam' ], pfam_latest_link ])
 
-            ARIA2( ch_pfam_link )
-            ch_versions = ch_versions.mix( ARIA2.out.versions )
-            ch_pfam_db = ARIA2.out.downloaded_file
+            ARIA2_PFAM( ch_pfam_link )
+            ch_versions = ch_versions.mix( ARIA2_PFAM.out.versions )
+            ch_pfam_db = ARIA2_PFAM.out.downloaded_file
         } else {
             ch_pfam_db = channel.of([ [ id: 'pfam' ], pfam_db ])
         }
@@ -33,15 +36,16 @@ workflow DOMAIN_ANNOTATION {
 
         HMMSEARCH_PFAM( ch_input_for_hmmsearch )
         ch_versions = ch_versions.mix( HMMSEARCH_PFAM.out.versions.first() )
+        ch_pfam_domains = HMMSEARCH_PFAM.out.domain_summary
     }
 
     if (!skip_funfam) {
         if (!funfam_db) {
             ch_funfam_link = channel.of([ [ id: 'funfam' ], funfam_latest_link ])
 
-            ARIA2( ch_funfam_link )
-            ch_versions = ch_versions.mix( ARIA2.out.versions )
-            ch_funfam_db = ARIA2.out.downloaded_file
+            ARIA2_FUNFAM( ch_funfam_link )
+            ch_versions = ch_versions.mix( ARIA2_FUNFAM.out.versions )
+            ch_funfam_db = ARIA2_FUNFAM.out.downloaded_file
         } else {
             ch_funfam_db = channel.of([ [ id: 'funfam' ], funfam_db ])
         }
@@ -52,10 +56,11 @@ workflow DOMAIN_ANNOTATION {
 
         HMMSEARCH_FUNFAM( ch_input_for_hmmsearch )
         ch_versions = ch_versions.mix( HMMSEARCH_FUNFAM.out.versions.first() )
+        ch_funfam_domains = HMMSEARCH_FUNFAM.out.domain_summary
     }
 
     emit:
-    pfam_domains   = HMMSEARCH_PFAM.out.domain_summary
-    funfam_domains = HMMSEARCH_FUNFAM.out.domain_summary
+    pfam_domains   = ch_pfam_domains
+    funfam_domains = ch_funfam_domains
     versions       = ch_versions
 }

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -7,11 +7,11 @@ workflow DOMAIN_ANNOTATION {
     take:
     ch_fasta            // channel: [ val(meta), [ fasta ] ]
     skip_pfam           // boolean
-    pfam_latest_link    // string, path to the latest pfam HMM database, to download
     pfam_db             // string, path to the pfam HMM database, if already exists
+    pfam_latest_link    // string, path to the latest pfam HMM database, to download
     skip_funfam         // boolean
-    funfam_latest_link  // string, path to the latest funfam HMM database, to download
     funfam_db           // string, path to the funfam HMM database, if already exists
+    funfam_latest_link  // string, path to the latest funfam HMM database, to download
 
     main:
 

--- a/subworkflows/local/domain_annotation/main.nf
+++ b/subworkflows/local/domain_annotation/main.nf
@@ -1,12 +1,16 @@
-include { ARIA2           } from '../../../modules/nf-core/aria2/main'
-include { HMMER_HMMSEARCH } from '../../../modules/nf-core/hmmer/hmmsearch/main'
+include { ARIA2                               } from '../../../modules/nf-core/aria2/main'
+include { HMMER_HMMSEARCH as HMMSEARCH_PFAM   } from '../../../modules/nf-core/hmmer/hmmsearch/main'
+include { HMMER_HMMSEARCH as HMMSEARCH_FUNFAM } from '../../../modules/nf-core/hmmer/hmmsearch/main'
 
 workflow DOMAIN_ANNOTATION {
     take:
-    ch_fasta          // channel: [ val(meta), [ fasta ] ]
-    skip_pfam         // boolean
-    pfam_latest_link  // string, path to the latest pfam HMM database, to download
-    pfam_db           // string, path to the pfam HMM database, if already exists
+    ch_fasta            // channel: [ val(meta), [ fasta ] ]
+    skip_pfam           // boolean
+    pfam_latest_link    // string, path to the latest pfam HMM database, to download
+    pfam_db             // string, path to the pfam HMM database, if already exists
+    skip_funfam         // boolean
+    funfam_latest_link  // string, path to the latest funfam HMM database, to download
+    funfam_db           // string, path to the funfam HMM database, if already exists
 
     main:
 
@@ -27,11 +31,31 @@ workflow DOMAIN_ANNOTATION {
             .combine(ch_pfam_db)
             .map{ meta, seqs, _meta2, models -> [meta, models, seqs, false, false, true] }
 
-        HMMER_HMMSEARCH( ch_input_for_hmmsearch )
-        ch_versions = ch_versions.mix( HMMER_HMMSEARCH.out.versions.first() )
+        HMMSEARCH_PFAM( ch_input_for_hmmsearch )
+        ch_versions = ch_versions.mix( HMMSEARCH_PFAM.out.versions.first() )
+    }
+
+    if (!skip_funfam) {
+        if (!funfam_db) {
+            ch_funfam_link = channel.of([ [ id: 'funfam' ], funfam_latest_link ])
+
+            ARIA2( ch_funfam_link )
+            ch_versions = ch_versions.mix( ARIA2.out.versions )
+            ch_funfam_db = ARIA2.out.downloaded_file
+        } else {
+            ch_funfam_db = channel.of([ [ id: 'funfam' ], funfam_db ])
+        }
+
+        ch_input_for_hmmsearch = ch_fasta
+            .combine(ch_funfam_db)
+            .map{ meta, seqs, _meta2, models -> [meta, models, seqs, false, false, true] }
+
+        HMMSEARCH_FUNFAM( ch_input_for_hmmsearch )
+        ch_versions = ch_versions.mix( HMMSEARCH_FUNFAM.out.versions.first() )
     }
 
     emit:
-    pfam_domains = HMMER_HMMSEARCH.out.domain_summary
-    versions     = ch_versions
+    pfam_domains   = HMMSEARCH_PFAM.out.domain_summary
+    funfam_domains = HMMSEARCH_FUNFAM.out.domain_summary
+    versions       = ch_versions
 }

--- a/subworkflows/local/domain_annotation/meta.yml
+++ b/subworkflows/local/domain_annotation/meta.yml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "domain_annotation"
+description: Annotate amino acid fasta files with selected HMM libraries such as Pfam and FunFam
+keywords:
+  - fasta
+  - sequences
+  - domain
+  - annotation
+  - database
+  - download
+  - HMM
+components:
+  - aria2
+  - hmmer/hmmsearch
+input:
+  - ch_fasta:
+      type: file
+      description: |
+        Amino acid fasta file containing amino acid sequences for annotation
+  - skip_pfam:
+      type: boolean
+      description: |
+        Skip domain annotation with Pfam
+  - pfam_db:
+      type: string
+      description: |
+        Path to an existing HMM Pfam library on the system
+  - pfam_latest_link:
+      type: string
+      description: |
+        Path to the latest Pfam HMM database, to download
+  - skip_funfam:
+      type: boolean
+      description: |
+        Skip domain annotation with FunFam
+  - funfam_db:
+      type: string
+      description: |
+        Path to an existing HMM FunFam library on the system
+  - funfam_latest_link:
+      type: string
+      description: |
+        Path to the latest FunFam HMM database, to download
+output:
+  - pfam_domains:
+      type: file
+      description: |
+        domtbl.gz files with pfam domain annotation for input amino acid sequences
+  - funfam_domains:
+      type: file
+      description: |
+        domtbl.gz files with funfam domain annotation for input amino acid sequences
+  - versions:
+      type: file
+      description: |
+        Versions file containing the software versions used in the workflow
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/subworkflows/local/domain_annotation/meta.yml
+++ b/subworkflows/local/domain_annotation/meta.yml
@@ -24,7 +24,7 @@ input:
   - pfam_db:
       type: string
       description: |
-        Path to an existing HMM Pfam library on the system
+        Path to an existing HMM Pfam library on the system. If provided, the ARIA2_PFAM db download will be skipped.
   - pfam_latest_link:
       type: string
       description: |
@@ -36,7 +36,7 @@ input:
   - funfam_db:
       type: string
       description: |
-        Path to an existing HMM FunFam library on the system
+        Path to an existing HMM FunFam library on the system. If provided, the ARIA2_FUNFAM db download will be skipped.
   - funfam_latest_link:
       type: string
       description: |

--- a/subworkflows/local/domain_annotation/tests/main.nf.test
+++ b/subworkflows/local/domain_annotation/tests/main.nf.test
@@ -1,0 +1,67 @@
+nextflow_workflow {
+
+    name "Test Subworkflow DOMAIN_ANNOTATION"
+    script "../main.nf"
+    workflow "DOMAIN_ANNOTATION"
+
+    test("faa - domain annotation") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id: 'test' ],
+                    file(params.pipelines_testdata_base_path + '/testdata/test_proteins.faa', checkIfExists: true)
+                ])
+                input[1] = false                                                                                   // skip_pfam
+                input[2] = null                                                                                    // pfam_db
+                input[3] = params.pipelines_testdata_base_path + '/testdata/pfam/Pfam-A_test.hmm.gz'               // pfam_latest_link
+                input[4] = false                                                                                   // skip_funfam
+                input[5] = null                                                                                    // funfam_db
+                input[6] = params.pipelines_testdata_base_path + '/testdata/funfam/funfam-hmm3-v4_3_0_test.lib.gz' // funfam_latest_link
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    path(workflow.out.pfam_domains[0][1]).linesGzip[0..7],
+                    path(workflow.out.funfam_domains[0][1]).linesGzip[0..7],
+                    workflow.out.versions.collect { path(it).yaml }.unique()
+                    ).match()}
+            )
+        }
+    }
+
+    test("faa - domain annotation - stub") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id: 'test' ],
+                    file(params.pipelines_testdata_base_path + '/testdata/test_proteins.faa', checkIfExists: true)
+                ])
+                input[1] = false                                                                                   // skip_pfam
+                input[2] = null                                                                                    // pfam_db
+                input[3] = params.pipelines_testdata_base_path + '/testdata/pfam/Pfam-A_test.hmm.gz'               // pfam_latest_link
+                input[4] = false                                                                                   // skip_funfam
+                input[5] = null                                                                                    // funfam_db
+                input[6] = params.pipelines_testdata_base_path + '/testdata/funfam/funfam-hmm3-v4_3_0_test.lib.gz' // funfam_latest_link
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+}

--- a/subworkflows/local/domain_annotation/tests/main.nf.test
+++ b/subworkflows/local/domain_annotation/tests/main.nf.test
@@ -35,6 +35,36 @@ nextflow_workflow {
         }
     }
 
+    test("faa - pfam_db - skip_funfam") {
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id: 'test' ],
+                    file(params.pipelines_testdata_base_path + '/testdata/test_proteins.faa', checkIfExists: true)
+                ])
+                input[1] = false                                                                                   // skip_pfam
+                input[2] = params.pipelines_testdata_base_path + '/testdata/pfam/Pfam-A_test.hmm.gz'               // pfam_db
+                input[3] = params.pipelines_testdata_base_path + '/testdata/pfam/Pfam-A_test.hmm.gz'               // pfam_latest_link
+                input[4] = true                                                                                    // skip_funfam
+                input[5] = null                                                                                    // funfam_db
+                input[6] = params.pipelines_testdata_base_path + '/testdata/funfam/funfam-hmm3-v4_3_0_test.lib.gz' // funfam_latest_link
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    path(workflow.out.pfam_domains[0][1]).linesGzip[0..7],
+                    workflow.out.versions.collect { path(it).yaml }.unique()
+                    ).match()}
+            )
+        }
+    }
+
     test("faa - domain annotation - stub") {
 
         options "-stub"

--- a/subworkflows/local/domain_annotation/tests/main.nf.test.snap
+++ b/subworkflows/local/domain_annotation/tests/main.nf.test.snap
@@ -1,0 +1,108 @@
+{
+    "faa - domain annotation": {
+        "content": [
+            [
+                "#                                                                            --- full sequence --- -------------- this domain -------------   hmm coord   ali coord   env coord",
+                "# target name        accession   tlen query name           accession   qlen   E-value  score  bias   #  of  c-Evalue  i-Evalue  score  bias  from    to  from    to  from    to  acc description of target",
+                "#------------------- ---------- ----- -------------------- ---------- ----- --------- ------ ----- --- --- --------- --------- ------ ----- ----- ----- ----- ----- ----- ----- ---- ---------------------",
+                "T1026                -            172 Nanovirus_coat       PF04660.18   177   1.2e-54  172.1   0.5   1   1   6.7e-55   1.3e-54  172.0   0.5     3   177     4   172     2   172 0.94 FBNSV, , 172 residues|",
+                "T1026                -            172 PUA_NSUN2            PF25378.2     87   1.8e-05   12.2   0.0   1   1   1.3e-05   2.7e-05   11.6   0.0    40    81    68   111    40   116 0.89 FBNSV, , 172 residues|",
+                "T1024                -            408 MFS_1                PF07690.22   347   6.7e-35  107.6  58.0   1   2   1.4e-32   2.9e-32   98.9  38.6     4   346    17   365    15   366 0.78 LmrP, , 408 residues|",
+                "T1024                -            408 MFS_1                PF07690.22   347   6.7e-35  107.6  58.0   2   2   2.6e-09   5.1e-09   22.5  11.4    38   174   262   399   257   407 0.74 LmrP, , 408 residues|",
+                "#"
+            ],
+            [
+                "#                                                                              --- full sequence --- -------------- this domain -------------   hmm coord   ali coord   env coord",
+                "# target name        accession   tlen query name             accession   qlen   E-value  score  bias   #  of  c-Evalue  i-Evalue  score  bias  from    to  from    to  from    to  acc description of target",
+                "#------------------- ---------- -----   -------------------- ---------- ----- --------- ------ ----- --- --- --------- --------- ------ ----- ----- ----- ----- ----- ----- ----- ---- ---------------------",
+                "T1024                -            408 1.20.1250.20-FF-000637 -            179     1e-09   25.7   6.6   1   2   5.2e-10     1e-09   25.7   6.6    17   173    32   191    24   197 0.81 LmrP, , 408 residues|",
+                "T1024                -            408 1.20.1250.20-FF-000637 -            179     1e-09   25.7   6.6   2   2     0.046     0.093   -0.2   5.0    30   137   261   367   248   402 0.64 LmrP, , 408 residues|",
+                "T1026                -            172 1.10.238.10-FF-000755 -             78   1.2e-05   12.7   0.1   1   2   1.6e-05   3.2e-05   11.3   0.0    16    54    39    79    29    90 0.73 FBNSV, , 172 residues|",
+                "T1026                -            172 1.10.238.10-FF-000755 -             78   1.2e-05   12.7   0.1   2   2       0.3       0.6   -2.4   0.0    38    49   102   113    97   123 0.74 FBNSV, , 172 residues|",
+                "#"
+            ],
+            [
+                {
+                    "DOMAIN_ANNOTATION:HMMSEARCH_FUNFAM": {
+                        "hmmer": 3.4
+                    }
+                },
+                {
+                    "DOMAIN_ANNOTATION:ARIA2_FUNFAM": {
+                        "aria2": "1.36.0"
+                    }
+                },
+                {
+                    "DOMAIN_ANNOTATION:ARIA2_PFAM": {
+                        "aria2": "1.36.0"
+                    }
+                },
+                {
+                    "DOMAIN_ANNOTATION:HMMSEARCH_PFAM": {
+                        "hmmer": 3.4
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2025-12-05T08:44:26.478981734"
+    },
+    "faa - domain annotation - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,160d4c5a5001cfb4ff57b94fc52b67d9",
+                    "versions.yml:md5,35e41735706132967dd94bb636833a4a",
+                    "versions.yml:md5,a74a0c8fcb741e59bc14424f612b8d09",
+                    "versions.yml:md5,f1d8a406d3dcb97a7c15e9c810926de1"
+                ],
+                "funfam_domains": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "pfam_domains": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.domtbl.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,160d4c5a5001cfb4ff57b94fc52b67d9",
+                    "versions.yml:md5,35e41735706132967dd94bb636833a4a",
+                    "versions.yml:md5,a74a0c8fcb741e59bc14424f612b8d09",
+                    "versions.yml:md5,f1d8a406d3dcb97a7c15e9c810926de1"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2025-12-05T08:44:37.015452047"
+    }
+}

--- a/subworkflows/local/domain_annotation/tests/main.nf.test.snap
+++ b/subworkflows/local/domain_annotation/tests/main.nf.test.snap
@@ -50,6 +50,32 @@
         },
         "timestamp": "2025-12-05T08:44:26.478981734"
     },
+    "faa - pfam_db - skip_funfam": {
+        "content": [
+            [
+                "#                                                                            --- full sequence --- -------------- this domain -------------   hmm coord   ali coord   env coord",
+                "# target name        accession   tlen query name           accession   qlen   E-value  score  bias   #  of  c-Evalue  i-Evalue  score  bias  from    to  from    to  from    to  acc description of target",
+                "#------------------- ---------- ----- -------------------- ---------- ----- --------- ------ ----- --- --- --------- --------- ------ ----- ----- ----- ----- ----- ----- ----- ---- ---------------------",
+                "T1026                -            172 Nanovirus_coat       PF04660.18   177   1.2e-54  172.1   0.5   1   1   6.7e-55   1.3e-54  172.0   0.5     3   177     4   172     2   172 0.94 FBNSV, , 172 residues|",
+                "T1026                -            172 PUA_NSUN2            PF25378.2     87   1.8e-05   12.2   0.0   1   1   1.3e-05   2.7e-05   11.6   0.0    40    81    68   111    40   116 0.89 FBNSV, , 172 residues|",
+                "T1024                -            408 MFS_1                PF07690.22   347   6.7e-35  107.6  58.0   1   2   1.4e-32   2.9e-32   98.9  38.6     4   346    17   365    15   366 0.78 LmrP, , 408 residues|",
+                "T1024                -            408 MFS_1                PF07690.22   347   6.7e-35  107.6  58.0   2   2   2.6e-09   5.1e-09   22.5  11.4    38   174   262   399   257   407 0.74 LmrP, , 408 residues|",
+                "#"
+            ],
+            [
+                {
+                    "DOMAIN_ANNOTATION:HMMSEARCH_PFAM": {
+                        "hmmer": 3.4
+                    }
+                }
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2025-12-05T10:10:22.057426358"
+    },
     "faa - domain annotation - stub": {
         "content": [
             {

--- a/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinannotator_pipeline/main.nf
@@ -180,7 +180,7 @@ def toolCitationText() {
         params.skip_preprocessing ? "" : "Input sequences were preprocessed with SeqKit (gap trimming, length filtering, validation, duplicate removal) (Shen et al. 2024)."
     ].join(' ').trim()
 
-    def domain_annotation_text = params.skip_pfam ? "" : "Pfam domains were annotated with hmmer/hmmsearch (Eddy et al. 2011)."
+    def domain_annotation_text = (params.skip_pfam && params.skip_funfam) ? "" : "Domains were annotated with hmmer/hmmsearch (Eddy et al. 2011)."
 
     def prediction_text = params.skip_s4pred ? "" : "Secondary structures were predicted via the s4pred software (Moffat et al. 2021)."
 
@@ -202,7 +202,7 @@ def toolBibliographyText() {
         params.skip_preprocessing ? '' : '<li>Shen, W., Sipos, B., & Zhao, L. (2024). SeqKit2: A Swiss army knife for sequence and alignment processing. Imeta, 3(3), e191. doi: <a href="https://doi.org/10.1002/imt2.191">10.1002/imt2.191</a></li>'
     ].join(' ').trim()
 
-    def domain_annotation_text = params.skip_pfam ? '' : '<li>Eddy, S. R. (2011). Accelerated profile HMM searches. PLoS computational biology, 7(10), e1002195. doi: <a href="https://doi.org/10.1371/journal.pcbi.1002195">10.1371/journal.pcbi.1002195</a></li>'
+    def domain_annotation_text = (params.skip_pfam && params.skip_funfam) ? '' : '<li>Eddy, S. R. (2011). Accelerated profile HMM searches. PLoS computational biology, 7(10), e1002195. doi: <a href="https://doi.org/10.1371/journal.pcbi.1002195">10.1371/journal.pcbi.1002195</a></li>'
 
     def prediction_text = params.skip_s4pred ? '' : '<li>Moffat, L., & Jones, D. T. (2021). Increasing the accuracy of single sequence prediction methods using a deep semi-supervised learning framework. Bioinformatics, 37(21), 3744-3751. doi: <a href="https://doi.org/10.1093/bioinformatics/btab491">10.1093/bioinformatics/btab491</a></li>'
 

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -10,3 +10,5 @@ multiqc/multiqc_report.html
 pipeline_info/*.{html,json,txt,yml}
 domain_annotation/pfam/T1024.domtbl.gz
 domain_annotation/pfam/T1026.domtbl.gz
+domain_annotation/funfam/T1024.domtbl.gz
+domain_annotation/funfam/T1026.domtbl.gz

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,12 +1,18 @@
 {
     "-profile test": {
         "content": [
-            16,
+            19,
             {
-                "ARIA2": {
+                "ARIA2_FUNFAM": {
                     "aria2": "1.36.0"
                 },
-                "HMMER_HMMSEARCH": {
+                "ARIA2_PFAM": {
+                    "aria2": "1.36.0"
+                },
+                "HMMSEARCH_FUNFAM": {
+                    "hmmer": 3.4
+                },
+                "HMMSEARCH_PFAM": {
                     "hmmer": 3.4
                 },
                 "S4PRED_RUNMODEL": {
@@ -33,11 +39,15 @@
             },
             [
                 "domain_annotation",
+                "domain_annotation/funfam",
+                "domain_annotation/funfam/T1024.domtbl.gz",
+                "domain_annotation/funfam/T1026.domtbl.gz",
                 "domain_annotation/pfam",
                 "domain_annotation/pfam/T1024.domtbl.gz",
                 "domain_annotation/pfam/T1026.domtbl.gz",
                 "downloaded_dbs",
                 "downloaded_dbs/Pfam-A_test.hmm.gz",
+                "downloaded_dbs/funfam-hmm3-v4_3_0_test.lib.gz",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/llms-full.txt",
@@ -95,6 +105,7 @@
             ],
             [
                 "Pfam-A_test.hmm.gz:md5,a5ab72b2b7bc72c62756684707e2387c",
+                "funfam-hmm3-v4_3_0_test.lib.gz:md5,df8b324882e1ceb8f8196155a968ed77",
                 "multiqc_T1024_after.txt:md5,f2a552d4750ff8360941b10cec141499",
                 "multiqc_T1024_before.txt:md5,f2a552d4750ff8360941b10cec141499",
                 "multiqc_T1026_after.txt:md5,aabd4e58ed67d366fd04592ca09dbc9b",
@@ -120,6 +131,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2025-12-02T15:47:22.509332504"
+        "timestamp": "2025-12-05T08:51:15.803204902"
     }
 }

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -4,7 +4,6 @@
 ========================================================================================
 */
 
-// TODO nf-core: Specify any additional parameters here
 // Or any resources requirements
 params {
     modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
@@ -12,5 +11,3 @@ params {
 }
 
 aws.client.anonymous = true
-
-params.outdir = './results'

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -30,6 +30,9 @@ workflow PROTEINANNOTATOR {
     pfam_latest_link    // string, path to the latest pfam HMM database, to download
     pfam_db             // string, path to the pfam HMM database, if already exists
     skip_s4pred         // boolean
+    skip_funfam         // boolean
+    funfam_latest_link  // string, path to the latest pfam HMM database, to download
+    funfam_db           // string, path to the pfam HMM database, if already exists
 
     main:
 
@@ -47,7 +50,15 @@ workflow PROTEINANNOTATOR {
             [ meta, updated_fasta ]
         }
 
-    DOMAIN_ANNOTATION( ch_samplesheet_updated, skip_pfam, pfam_latest_link, pfam_db )
+    DOMAIN_ANNOTATION(
+        ch_samplesheet_updated,
+        skip_pfam,
+        pfam_latest_link,
+        pfam_db,
+        skip_funfam,
+        funfam_latest_link,
+        funfam_db
+    )
     ch_versions = ch_versions.mix( DOMAIN_ANNOTATION.out.versions )
 
     FUNCTIONAL_ANNOTATION( ch_samplesheet_updated )

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -27,11 +27,11 @@ workflow PROTEINANNOTATOR {
     ch_samplesheet      // channel: samplesheet read in from --input
     skip_preprocessing  // boolean
     skip_pfam           // boolean
-    pfam_latest_link    // string, path to the latest pfam HMM database, to download
     pfam_db             // string, path to the pfam HMM database, if already exists
+    pfam_latest_link    // string, path to the latest pfam HMM database, to download
     skip_funfam         // boolean
-    funfam_latest_link  // string, path to the latest pfam HMM database, to download
     funfam_db           // string, path to the pfam HMM database, if already exists
+    funfam_latest_link  // string, path to the latest pfam HMM database, to download
     skip_s4pred         // boolean
 
     main:

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -53,11 +53,11 @@ workflow PROTEINANNOTATOR {
     DOMAIN_ANNOTATION(
         ch_samplesheet_updated,
         skip_pfam,
-        pfam_latest_link,
         pfam_db,
+        pfam_latest_link,
         skip_funfam,
-        funfam_latest_link,
-        funfam_db
+        funfam_db,
+        funfam_latest_link
     )
     ch_versions = ch_versions.mix( DOMAIN_ANNOTATION.out.versions )
 

--- a/workflows/proteinannotator.nf
+++ b/workflows/proteinannotator.nf
@@ -29,10 +29,10 @@ workflow PROTEINANNOTATOR {
     skip_pfam           // boolean
     pfam_latest_link    // string, path to the latest pfam HMM database, to download
     pfam_db             // string, path to the pfam HMM database, if already exists
-    skip_s4pred         // boolean
     skip_funfam         // boolean
     funfam_latest_link  // string, path to the latest pfam HMM database, to download
     funfam_db           // string, path to the pfam HMM database, if already exists
+    skip_s4pred         // boolean
 
     main:
 


### PR DESCRIPTION
Also added a meta.yml and nf-test for the domain annotation subworkflow.

<!--
# nf-core/proteinannotator pull request

Many thanks for contributing to nf-core/proteinannotator!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/proteinannotator/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/proteinannotator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (e.g. `nf-test test */local --profile=~test,docker` for all new local tests).
- [ ] Check for unexpected warnings in debug mode (`nf-test test */local --profile=~test,docker,debug`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
  - [ ] `docs/images/proteinannotator-metromap.light.excalidraw.png` and `docs/images/proteinannotator-metromap.light.excalidraw.png` (edit the light version only, then export and turn on dark mode) are both updated (use the excalidraw [website](https://excalidraw.com/) or [VS Code](https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor) plugin to edit)
